### PR TITLE
v0.7.x: Migration Map, AI Discovery Dismiss, Debug Endpoints

### DIFF
--- a/.changelog/v0.6.33.md
+++ b/.changelog/v0.6.33.md
@@ -1,4 +1,4 @@
-# Release v0.6.x - FamilySearch Normalization & Architecture Refinement
+# Release v0.6.33 - FamilySearch Normalization & Architecture Refinement
 
 Released: YYYY-MM-DD
 
@@ -8,7 +8,7 @@ This release normalizes FamilySearch as a downstream provider (equal to Ancestry
 
 ## New Features
 
-### Ancestry Update Automation Page (v0.6.x)
+### Ancestry Update Automation Page (v0.6.33)
 - New database-scoped page at `/db/:dbId/ancestry-update` for bulk Ancestry synchronization
 - BFS traversal of direct-ancestor sparse tree from selected root person
 - Configurable generation depth (1-4 or full tree)
@@ -18,7 +18,7 @@ This release normalizes FamilySearch as a downstream provider (equal to Ancestry
 - Adds "Ancestry Update" link to database sidebar
 - API endpoints: GET `/api/ancestry-update/status`, GET `/:dbId/events` (SSE), POST `/:dbId/cancel`, GET `/:dbId/validate/:personId`
 
-### Ancestry Free Hints Automation (v0.6.x)
+### Ancestry Free Hints Automation (v0.6.33)
 - New "Hints" button on Ancestry row in Provider Data table to process free record hints
 - Playwright automation navigates to hints page, reviews each hint, accepts and saves to tree
 - Supports checkbox selection for adding related people from hints
@@ -26,7 +26,7 @@ This release normalizes FamilySearch as a downstream provider (equal to Ancestry
 - SSE-based progress events for real-time UI updates
 - API endpoints: POST/GET `/api/ancestry-hints/:dbId/:personId`, cancel, status
 
-### Ancestry Vital Info Upload (v0.6.x)
+### Ancestry Vital Info Upload (v0.6.33)
 - Extended Ancestry upload to support birth date, birth place, death date, death place, and name (not just photos)
 - Upload dialog now shows field-by-field comparison between local SparseTree data and cached Ancestry data
 - Browser automation uses Ancestry's Quick Edit sidebar to update person facts
@@ -39,69 +39,69 @@ This release normalizes FamilySearch as a downstream provider (equal to Ancestry
 - Added `linkFamilySearch()` and `getFamilySearchPhotoPath()` to augmentation service
 - ID resolution uses alphabetical order (no FamilySearch priority)
 
-### Architecture: Source of Truth Principle (v0.6.x)
+### Architecture: Source of Truth Principle (v0.6.33)
 - SparseTree SQLite is now the canonical source of truth
 - Provider cache (`data/provider-cache/`) is for comparison only, not a fallback data source
 - All data reads come from SQLite; provider cache shows what providers have vs what SparseTree has
 
 ## Bug Fixes
 
-### SQLite Vital Event Row ID Preservation (v0.6.x)
+### SQLite Vital Event Row ID Preservation (v0.6.33)
 - Changed vital_event INSERT from `INSERT OR REPLACE` to `ON CONFLICT DO UPDATE`
 - Preserves row IDs which are critical for local_override references
 - INSERT OR REPLACE was deleting and re-inserting rows, orphaning override references
 
-### Improved Vital Event Date Parsing (v0.6.x)
+### Improved Vital Event Date Parsing (v0.6.33)
 - Now uses actual `birth.date` and `death.date` objects instead of parsing lifespan string
 - Captures full dates (e.g., "1979-07-31") rather than just years from lifespan ("1979-2020")
 - Added `parseYearFromDate()` function to handle various date formats including BC notation
 
-### Ancestry Update Log Memory Fix (v0.6.x)
+### Ancestry Update Log Memory Fix (v0.6.33)
 - Limited execution log entries to 500 to prevent browser memory issues on large trees
 - Shows notice when older entries are truncated
 
-### FamilySearch Upload Improvements (v0.6.x)
+### FamilySearch Upload Improvements (v0.6.33)
 - Auto-refresh FamilySearch cache after successful upload so UI shows updated data
 - Improved photo comparison to detect already-uploaded photos via symlink matching
 - Fixed Google login button selector for updated FamilySearch login page
 - Improved vitals page editing: handles conclusion dialogs and edit buttons
 - Added autocomplete handling for date/place fields (clicks first suggestion)
 
-### Scraper Auto-Login (v0.6.x)
+### Scraper Auto-Login (v0.6.33)
 - Scraper now attempts auto-login via Google OAuth when landing on FamilySearch login page
 - Added `handleLoginIfNeeded()` function to detect login pages and complete OAuth flow
 - Navigates directly to target URL after successful login
 
-### Provider Comparison Not Using Local Overrides (v0.6.x)
+### Provider Comparison Not Using Local Overrides (v0.6.33)
 - Fixed comparison service using original database values instead of user-applied overrides
 - Added `applyLocalOverrides()` to fetch and apply vital_event overrides before comparison
 - FamilySearch/Ancestry now correctly show "match" when user has applied their values
 
-### Date Format Differences Showing as Different (v0.6.x)
+### Date Format Differences Showing as Different (v0.6.33)
 - Added date normalization to expand month abbreviations (e.g., "AUG" → "august")
 - "29 AUG 1933" now correctly matches "29 August 1933"
 - Reduces false positives in provider comparison diff counts
 
-### Unicode Escape in View Mode Selector (v0.6.x)
+### Unicode Escape in View Mode Selector (v0.6.33)
 - Fixed checkmark showing as literal `\u2713` text instead of ✓ in tree view mode dropdown
 - JSX text content requires actual Unicode characters, not escape sequences
 
-### Fan Chart Ancestor Count (v0.6.x)
+### Fan Chart Ancestor Count (v0.6.33)
 - Fixed footer showing incorrect count like "109 of 62 ancestors shown"
 - Now correctly counts only ancestors within the visible generation range
 
-### Stale Browser Connection Detection (v0.6.x)
+### Stale Browser Connection Detection (v0.6.33)
 - Added `verifyAndReconnect()` to browser service that checks both Playwright state and actual browser process
 - Augmentation service now detects and recovers from stale connections before scraping
 - Fixes silent failures when browser was closed but connection state was still "connected"
 
-### Auto-Login on Sync (v0.6.x)
+### Auto-Login on Sync (v0.6.33)
 - FamilySearch sync now attempts automatic login when auth token is missing
 - Uses `providerService.ensureAuthenticated()` to try Google SSO or stored credentials
 - Eliminates need for manual browser login before sync operations
 - Applies to both `refreshPerson()` and `fetchPersonDisplayName()` methods
 
-### FamilySearch Scraper Not Extracting Data (v0.6.x)
+### FamilySearch Scraper Not Extracting Data (v0.6.33)
 - Updated scraper selectors to match current FamilySearch DOM structure
 - Name now extracted using `[data-testid="fullName"]`
 - Birth/death dates now extracted from `[data-testid="conclusionDisplay:BIRTH"]` and `[data-testid="conclusionDisplay:DEATH"]` containers
@@ -111,7 +111,7 @@ This release normalizes FamilySearch as a downstream provider (equal to Ancestry
 - Added detailed debug logging for photo extraction troubleshooting
 - Improved UI feedback: loading toast during scrape, success toast shows extracted fields
 
-### "Use" Button Not Updating SparseTree Row (v0.6.x)
+### "Use" Button Not Updating SparseTree Row (v0.6.33)
 - Fixed clicking "Use" on provider field values not updating the SparseTree row display
 - Root causes fixed:
   - Client: `onFieldChanged` callback now refetches person data after applying override
@@ -119,7 +119,7 @@ This release normalizes FamilySearch as a downstream provider (equal to Ancestry
 - Added `applyLocalOverridesToPerson()` to database service for consistent override application
 - Birth/death date/place values from providers now properly display after clicking "Use"
 
-### "Set as Primary" Photo Not Updating (v0.6.x)
+### "Set as Primary" Photo Not Updating (v0.6.33)
 - Fixed photo not updating after clicking "Set as Primary" on provider photos
 - Root causes fixed:
   - `getPhotoPath()` now checks for primary photo (`{personId}.jpg`) before provider-suffixed photos
@@ -129,27 +129,27 @@ This release normalizes FamilySearch as a downstream provider (equal to Ancestry
 - Added client API methods: `getFsPhotoUrl()`, `hasFsPhotoProvider()`
 - Added `photoVersion` state for cache-busting photo URLs after changes
 
-### HMR Context Resilience (v0.6.x)
+### HMR Context Resilience (v0.6.33)
 - Fixed "useSidebar must be used within a SidebarProvider" error during HMR transitions
 - `useSidebar()` and `useTheme()` hooks now return safe defaults during dev hot reloads
 - Prevents crashes when React context identity changes during development
 
 ## Improvements
 
-### FamilySearch Upload Performance (v0.6.x)
+### FamilySearch Upload Performance (v0.6.33)
 - Eliminated redundant post-login delays in FamilySearch upload automation
 - After Google OAuth redirect, now checks if already on target page before re-navigating
 - Replaced fixed `waitForTimeout` delays with element-based `waitForSelector` for responsiveness
 - Added PM2 timestamps to server logs for better debugging (`time: true` in ecosystem config)
 
-### Page-Level Padding Control (v0.6.x)
+### Page-Level Padding Control (v0.6.33)
 - Moved `p-6` padding from Layout to individual pages for flexibility
 - Full-height pages (tree views, PersonDetail, SparseTreePage) control their own layout
 - Standard content pages receive consistent padding via their root element
 - Fixed missing padding on SparseTreePage and PersonDetail
 - Removed double padding from AIProviders page (external component handles its own padding)
 
-### Tree Visualization Parity with Ancestry.com (v0.6.x)
+### Tree Visualization Parity with Ancestry.com (v0.6.33)
 - Added 5 tree view modes matching Ancestry.com functionality
 - **Fan Chart** (default): Radial pedigree with lineage-colored wedges (paternal=blue/teal, maternal=red/coral)
 - **Horizontal Pedigree**: Root left, ancestors right with expandable nodes
@@ -160,7 +160,7 @@ This release normalizes FamilySearch as a downstream provider (equal to Ancestry
 - New utilities: lineageColors, treeLayout, arcGenerator
 - Fixed classic view bugs: dynamic centering, ResizeObserver instead of setTimeout
 
-### Vertical Family View Improvements (v0.6.x)
+### Vertical Family View Improvements (v0.6.33)
 - Refactored layout to use multi-pass collision resolution algorithm
 - Parents properly avoid overlapping when multiple branches are expanded
 - Added horizontal coupling bars between parent pairs (matching Ancestry.com style)
@@ -170,13 +170,13 @@ This release normalizes FamilySearch as a downstream provider (equal to Ancestry
 - Fixed expand/collapse button positioning to overlap card tops consistently
 - Moved spouse connection line from middle of card to name/date area
 
-### Avatar Placeholders (v0.6.x)
+### Avatar Placeholders (v0.6.33)
 - Replaced emoji-based avatar placeholders with proper SVG components throughout tree views
 - New `AvatarPlaceholder` component renders gender-aware silhouettes (male/female/unknown profiles)
 - Updated PersonCard, FocusNavigatorView, GenerationalColumnsView, PedigreeChartView, and SparseTreePage
 - Softened gender color palette for better visual harmony (less saturated blue/pink)
 
-### Legacy Code Removal (v0.6.x)
+### Legacy Code Removal (v0.6.33)
 - Removed all legacy fallback code from services (no more dual-path lookups)
 - Services updated: `familysearch-refresh`, `multi-platform-comparison`, `augmentation`, `scraper`, `person.routes`
 - Architecture policy: use migration scripts instead of maintaining legacy paths
@@ -213,4 +213,4 @@ This release normalizes FamilySearch as a downstream provider (equal to Ancestry
 
 ## Full Changelog
 
-**Full Diff**: https://github.com/atomantic/SparseTree/compare/v0.5.4...v0.6.x
+**Full Diff**: https://github.com/atomantic/SparseTree/compare/v0.5.4...v0.6.33

--- a/.changelog/v0.7.x.md
+++ b/.changelog/v0.7.x.md
@@ -1,0 +1,33 @@
+# Release v0.7.x - AI Discovery Improvements
+
+Released: YYYY-MM-DD
+
+## Overview
+
+This release improves the AI Discovery feature with dismiss functionality, debugging capabilities, and better CLI integration.
+
+## New Features
+
+### AI Discovery Dismiss Functionality (v0.7.0)
+- Dismiss AI-discovered candidates to exclude them from future discoveries
+- Batch dismiss all unselected candidates at once
+- View dismissed candidates with original AI reasoning and tags
+- Undo dismiss to restore candidates
+- Clear all dismissed candidates for a database
+- Dismissed candidates stored in SQLite with `discovery_dismissed` table
+- API endpoints: POST `/dismiss`, POST `/dismiss-batch`, GET `/dismissed`, DELETE `/dismissed/:personId`, DELETE `/dismissed`
+
+### AI Discovery Debug Endpoints (v0.7.0)
+- New debug endpoints for troubleshooting AI run failures
+- GET `/api/ai-discovery/debug/runs` - list recent AI runs with metadata
+- GET `/api/ai-discovery/debug/runs/:runId` - detailed run info including prompt preview and output
+- Error details capture (last 10 lines of stderr/stdout) stored on failed runs
+
+## Bug Fixes
+
+### CLI Provider Integration (v0.7.0)
+- Fixed large prompt handling via stdin piping for CLI providers (codex, claude-code)
+- Added `-` flag detection in provider args to enable stdin mode
+- Fixed JSON parsing to find LAST valid JSON array in noisy CLI output
+- Handles CLI banners and headers that could interfere with response parsing
+- Improved error capture with `errorDetails` field for debugging failures

--- a/.changelog/v0.7.x.md
+++ b/.changelog/v0.7.x.md
@@ -1,6 +1,6 @@
 # Release v0.7.x - Migration Map, AI Discovery Improvements
 
-Released: YYYY-MM-DD
+Released: Unreleased
 
 ## Overview
 

--- a/.changelog/v0.7.x.md
+++ b/.changelog/v0.7.x.md
@@ -1,4 +1,4 @@
-# Release v0.7.x - AI Discovery Improvements
+# Release v0.7.x - Migration Map, AI Discovery Improvements
 
 Released: YYYY-MM-DD
 

--- a/.changelog/v0.7.x.md
+++ b/.changelog/v0.7.x.md
@@ -23,6 +23,19 @@ This release improves the AI Discovery feature with dismiss functionality, debug
 - GET `/api/ai-discovery/debug/runs/:runId` - detailed run info including prompt preview and output
 - Error details capture (last 10 lines of stderr/stdout) stored on failed runs
 
+### Migration Map Visualization (v0.7.x)
+- New 6th tree view mode: "Migration Map" plots ancestors on an interactive world map
+- Leaflet.js map with OpenStreetMap/CartoDB dark tiles
+- Lineage-colored markers (paternal=blue, maternal=red) with generation depth variation
+- Migration polylines connecting parent birth to child birth locations
+- Time range slider for filtering by birth year
+- Paternal/Maternal layer toggle checkboxes
+- Geocoding via Nominatim with permanent SQLite cache (`place_geocode` table)
+- Progressive geocode broadening: strips specific locality parts to resolve historical place names
+- User-initiated batch geocoding with SSE progress streaming (EventSource)
+- Sparse tree map page at `/favorites/sparse-tree/:dbId/map`
+- API: `GET /api/map/:dbId/:personId`, `GET /api/map/:dbId/sparse`, `GET /api/map/geocode/stream`
+
 ## Bug Fixes
 
 ### CLI Provider Integration (v0.7.0)

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A genealogy toolkit for creating local databases of your family tree, curating favorites, and generating sparse family tree visualizations.
 
+## Origins
+
+This project is a web-based UI enhancement that evolved from the creator's early explorations into learning more about his ancestry using a CLI-based tool: [FamilySearchFinder](https://github.com/atomantic/FamilySearchFinder).
+
 ## What is SparseTree?
 
 SparseTree connects to genealogy providers (FamilySearch, Ancestry, WikiTree, 23andMe) to download and store your ancestry data locally. Once you have your data, you can:

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fsf/client",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "type": "module",
   "scripts": {
     "dev": "vite --port 6373",

--- a/client/package.json
+++ b/client/package.json
@@ -10,17 +10,20 @@
   "dependencies": {
     "@fsf/shared": "*",
     "d3": "^7.9.0",
+    "leaflet": "^1.9.4",
     "lucide-react": "^0.562.0",
     "portos-ai-toolkit": "^0.1.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-hot-toast": "^2.6.0",
+    "react-leaflet": "^4.2.1",
     "react-router-dom": "^7.1.1",
     "socket.io-client": "^4.8.3",
     "zustand": "^5.0.2"
   },
   "devDependencies": {
     "@types/d3": "^7.4.3",
+    "@types/leaflet": "^1.9.21",
     "@types/react": "^18.3.18",
     "@types/react-dom": "^18.3.5",
     "@vitejs/plugin-react": "^4.3.4",

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fsf/client",
-  "version": "0.7.5",
+  "version": "0.7.6",
   "type": "module",
   "scripts": {
     "dev": "vite --port 6373",

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fsf/client",
-  "version": "0.7.7",
+  "version": "0.7.8",
   "type": "module",
   "scripts": {
     "dev": "vite --port 6373",

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fsf/client",
-  "version": "0.7.11",
+  "version": "0.7.12",
   "type": "module",
   "scripts": {
     "dev": "vite --port 6373",

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fsf/client",
-  "version": "0.7.10",
+  "version": "0.7.11",
   "type": "module",
   "scripts": {
     "dev": "vite --port 6373",

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fsf/client",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "type": "module",
   "scripts": {
     "dev": "vite --port 6373",

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fsf/client",
-  "version": "0.7.8",
+  "version": "0.7.9",
   "type": "module",
   "scripts": {
     "dev": "vite --port 6373",

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fsf/client",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "type": "module",
   "scripts": {
     "dev": "vite --port 6373",

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fsf/client",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "type": "module",
   "scripts": {
     "dev": "vite --port 6373",

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fsf/client",
-  "version": "0.6.33",
+  "version": "0.7.0",
   "type": "module",
   "scripts": {
     "dev": "vite --port 6373",

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fsf/client",
-  "version": "0.7.9",
+  "version": "0.7.10",
   "type": "module",
   "scripts": {
     "dev": "vite --port 6373",

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fsf/client",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "type": "module",
   "scripts": {
     "dev": "vite --port 6373",

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fsf/client",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "type": "module",
   "scripts": {
     "dev": "vite --port 6373",

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -13,6 +13,7 @@ import { BrowserSettingsPage } from './pages/BrowserSettingsPage';
 import { ReportsPage } from './pages/ReportsPage';
 import { FavoritesPage } from './components/favorites/FavoritesPage';
 import { SparseTreePage } from './components/favorites/SparseTreePage';
+import { SparseTreeMapPage } from './components/favorites/SparseTreeMapPage';
 import { DatabaseFavoritesPage } from './components/favorites/DatabaseFavoritesPage';
 import { IntegrityPage } from './components/integrity/IntegrityPage';
 import { AncestryUpdatePage } from './components/ancestry-update';
@@ -41,6 +42,7 @@ function App() {
         <Route path="tools/gedcom" element={<GedcomPage />} />
         <Route path="favorites" element={<FavoritesPage />} />
         <Route path="favorites/sparse-tree/:dbId" element={<SparseTreePage />} />
+        <Route path="favorites/sparse-tree/:dbId/map" element={<SparseTreeMapPage />} />
         <Route path="db/:dbId/favorites" element={<DatabaseFavoritesPage />} />
         <Route path="db/:dbId/integrity" element={<IntegrityPage />} />
         <Route path="db/:dbId/integrity/:tab" element={<IntegrityPage />} />

--- a/client/src/components/ai/AiDiscoveryModal.tsx
+++ b/client/src/components/ai/AiDiscoveryModal.tsx
@@ -73,9 +73,7 @@ export function AiDiscoveryModal({ dbId, onClose, onComplete }: AiDiscoveryModal
   };
 
   const selectAll = () => {
-    if (result) {
-      setSelectedCandidates(new Set(result.candidates.map(c => c.personId)));
-    }
+    setSelectedCandidates(new Set(visibleCandidates.map(c => c.personId)));
   };
 
   const selectNone = () => {
@@ -86,7 +84,7 @@ export function AiDiscoveryModal({ dbId, onClose, onComplete }: AiDiscoveryModal
     if (!result) return;
 
     setApplying(true);
-    const candidatesToApply = result.candidates.filter(c => selectedCandidates.has(c.personId));
+    const candidatesToApply = visibleCandidates.filter(c => selectedCandidates.has(c.personId));
 
     api.applyDiscoveryBatch(dbId, candidatesToApply)
       .then(data => {

--- a/client/src/components/ancestry-tree/AncestryTreeView.tsx
+++ b/client/src/components/ancestry-tree/AncestryTreeView.tsx
@@ -102,7 +102,10 @@ export function AncestryTreeView() {
     setMapLoading(true);
     api.getAncestryMapData(dbId, rootId, 8)
       .then(data => setMapData(data))
-      .catch(err => console.error('Failed to load map data:', err))
+      .catch(err => {
+        console.error('Failed to load map data:', err);
+        setError(err.message);
+      })
       .finally(() => setMapLoading(false));
   }, [dbId, rootId, viewMode]);
 

--- a/client/src/components/ancestry-tree/AncestryTreeView.tsx
+++ b/client/src/components/ancestry-tree/AncestryTreeView.tsx
@@ -74,9 +74,13 @@ export function AncestryTreeView() {
     }
   }, [dbId, personId]);
 
-  // Load ancestry tree data
+  // Load ancestry tree data (skip for map view which loads its own data)
   useEffect(() => {
     if (!dbId || !rootId) return;
+    if (viewMode === 'map') {
+      setLoading(false);
+      return;
+    }
 
     setLoading(true);
     setError(null);
@@ -200,8 +204,8 @@ export function AncestryTreeView() {
     );
   }
 
-  // No data state
-  if (!treeData) {
+  // No data state (skip for map view which loads its own data)
+  if (!treeData && viewMode !== 'map') {
     return (
       <div className="flex items-center justify-center h-full">
         <p className="text-app-text-muted">No tree data available</p>
@@ -217,7 +221,7 @@ export function AncestryTreeView() {
       <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 px-4 py-3 border-b border-app-border bg-app-card">
         <div className="flex items-center gap-2 sm:gap-4 min-w-0">
           <h1 className="text-lg sm:text-xl font-bold text-app-text whitespace-nowrap">Ancestry Tree</h1>
-          <span className="text-sm text-app-text-muted truncate">{treeData.rootPerson.name}</span>
+          <span className="text-sm text-app-text-muted truncate">{treeData?.rootPerson?.name}</span>
         </div>
 
         {/* View mode dropdown and navigation */}
@@ -280,11 +284,11 @@ export function AncestryTreeView() {
 
       {/* View content */}
       <div className="flex-1 overflow-hidden">
-        {viewMode === 'fan' && (
+        {viewMode === 'fan' && treeData && (
           <FanChartView data={treeData} dbId={dbId!} />
         )}
 
-        {viewMode === 'horizontal' && (
+        {viewMode === 'horizontal' && treeData && (
           <HorizontalPedigreeView
             data={treeData}
             dbId={dbId!}
@@ -293,7 +297,7 @@ export function AncestryTreeView() {
           />
         )}
 
-        {viewMode === 'vertical' && (
+        {viewMode === 'vertical' && treeData && (
           <VerticalFamilyView
             data={treeData}
             dbId={dbId!}
@@ -302,7 +306,7 @@ export function AncestryTreeView() {
           />
         )}
 
-        {viewMode === 'columns' && (
+        {viewMode === 'columns' && treeData && (
           <GenerationalColumnsView
             data={treeData}
             dbId={dbId!}
@@ -311,7 +315,7 @@ export function AncestryTreeView() {
           />
         )}
 
-        {viewMode === 'focus' && (
+        {viewMode === 'focus' && treeData && (
           <FocusNavigatorView data={treeData} dbId={dbId!} />
         )}
 

--- a/client/src/components/ancestry-tree/AncestryTreeView.tsx
+++ b/client/src/components/ancestry-tree/AncestryTreeView.tsx
@@ -100,12 +100,10 @@ export function AncestryTreeView() {
   const loadMapData = useCallback(() => {
     if (!dbId || !rootId || viewMode !== 'map') return;
     setMapLoading(true);
+    setError(null);
     api.getAncestryMapData(dbId, rootId, 8)
       .then(data => setMapData(data))
-      .catch(err => {
-        console.error('Failed to load map data:', err);
-        setError(err.message);
-      })
+      .catch(err => setError(err.message))
       .finally(() => setMapLoading(false));
   }, [dbId, rootId, viewMode]);
 

--- a/client/src/components/ancestry-tree/AncestryTreeView.tsx
+++ b/client/src/components/ancestry-tree/AncestryTreeView.tsx
@@ -326,7 +326,7 @@ export function AncestryTreeView() {
           <MigrationMapView
             mapData={mapData}
             dbId={dbId!}
-            loading={mapLoading}
+            loading={mapLoading || mapData === null}
             onReload={loadMapData}
           />
         )}

--- a/client/src/components/ancestry-tree/views/MigrationMapView.tsx
+++ b/client/src/components/ancestry-tree/views/MigrationMapView.tsx
@@ -1,0 +1,289 @@
+/**
+ * Migration Map View
+ *
+ * Leaflet-based map showing ancestors plotted geographically with
+ * lineage-colored markers and parent-child migration lines.
+ *
+ * Features:
+ * - OpenStreetMap tiles (light) / CartoDB dark tiles
+ * - Lineage-colored markers (paternal=blue, maternal=red)
+ * - Parent-child migration polylines
+ * - Time range slider filtering by birth year
+ * - Layer controls for paternal/maternal toggle
+ * - Auto-fit bounds on load
+ * - Click popup with person details
+ */
+
+import { useEffect, useRef, useState, useMemo, useCallback } from 'react';
+import { MapContainer, TileLayer, Marker, Polyline, Popup, useMap } from 'react-leaflet';
+import type { MapPerson, MapData } from '@fsf/shared';
+import { GeocodeProgressBar } from '../../map/GeocodeProgressBar';
+import {
+  createPersonMarker,
+  buildPopupHtml,
+  getMigrationLineStyle,
+  buildMigrationLines,
+  calculateBounds,
+} from '../../map/mapUtils';
+
+import 'leaflet/dist/leaflet.css';
+
+// Fix Leaflet default icon issue with Vite
+import L from 'leaflet';
+// @ts-expect-error Leaflet icon path fix for bundlers
+delete L.Icon.Default.prototype._getIconUrl;
+L.Icon.Default.mergeOptions({
+  iconRetinaUrl: 'https://unpkg.com/leaflet@1.9.4/dist/images/marker-icon-2x.png',
+  iconUrl: 'https://unpkg.com/leaflet@1.9.4/dist/images/marker-icon.png',
+  shadowUrl: 'https://unpkg.com/leaflet@1.9.4/dist/images/marker-shadow.png',
+});
+
+interface MigrationMapViewProps {
+  mapData: MapData | null;
+  dbId: string;
+  loading: boolean;
+  onReload: () => void;
+}
+
+// Dark theme tile URL
+const DARK_TILES = 'https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png';
+const LIGHT_TILES = 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png';
+const DARK_ATTR = '&copy; <a href="https://www.openstreetmap.org/copyright">OSM</a> &copy; <a href="https://carto.com/">CARTO</a>';
+const LIGHT_ATTR = '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>';
+
+/**
+ * Auto-fit map bounds when data changes
+ */
+function FitBounds({ persons }: { persons: MapPerson[] }) {
+  const map = useMap();
+
+  useEffect(() => {
+    const bounds = calculateBounds(persons);
+    if (bounds) {
+      map.fitBounds(bounds as L.LatLngBoundsExpression, { padding: [40, 40], maxZoom: 8 });
+    }
+  }, [map, persons]);
+
+  return null;
+}
+
+export function MigrationMapView({ mapData, dbId, loading, onReload }: MigrationMapViewProps) {
+  const [timeRange, setTimeRange] = useState<[number, number]>([0, 2100]);
+  const [showPaternal, setShowPaternal] = useState(true);
+  const [showMaternal, setShowMaternal] = useState(true);
+  const [isDarkTheme, setIsDarkTheme] = useState(true);
+  const mapRef = useRef<L.Map | null>(null);
+
+  // Calculate year range from data
+  const yearRange = useMemo(() => {
+    if (!mapData) return { min: 0, max: 2100 };
+    let min = Infinity;
+    let max = -Infinity;
+    for (const p of mapData.persons) {
+      if (p.birthYear) {
+        min = Math.min(min, p.birthYear);
+        max = Math.max(max, p.birthYear);
+      }
+    }
+    if (!isFinite(min)) return { min: 0, max: 2100 };
+    // Round to nearest 50
+    return { min: Math.floor(min / 50) * 50, max: Math.ceil(max / 50) * 50 };
+  }, [mapData]);
+
+  // Initialize time range when data loads
+  useEffect(() => {
+    setTimeRange([yearRange.min, yearRange.max]);
+  }, [yearRange.min, yearRange.max]);
+
+  // Filter persons by time range and lineage visibility
+  const filteredPersons = useMemo(() => {
+    if (!mapData) return [];
+    return mapData.persons.filter(p => {
+      // Lineage filter
+      if (p.lineage === 'paternal' && !showPaternal) return false;
+      if (p.lineage === 'maternal' && !showMaternal) return false;
+
+      // Time filter (only filter if person has a birth year)
+      if (p.birthYear && (p.birthYear < timeRange[0] || p.birthYear > timeRange[1])) return false;
+
+      // Must have at least one geocoded coordinate
+      return p.birthCoords || p.deathCoords;
+    });
+  }, [mapData, showPaternal, showMaternal, timeRange]);
+
+  // Build migration lines
+  const migrationLines = useMemo(() => {
+    return buildMigrationLines(filteredPersons);
+  }, [filteredPersons]);
+
+  // Count markers with coords
+  const markersWithCoords = filteredPersons.filter(p => p.birthCoords || p.deathCoords).length;
+
+  const handleTimeChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = parseInt(e.target.value);
+    const isMin = e.target.dataset.range === 'min';
+    setTimeRange(prev => isMin ? [value, prev[1]] : [prev[0], value]);
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center h-full">
+        <div className="text-center">
+          <div className="w-8 h-8 border-4 border-app-male border-t-transparent rounded-full animate-spin mx-auto mb-4" />
+          <p className="text-app-text-muted">Loading map data...</p>
+        </div>
+      </div>
+    );
+  }
+
+  // Empty state
+  if (!mapData || mapData.persons.length === 0) {
+    return (
+      <div className="flex items-center justify-center h-full">
+        <div className="text-center max-w-md px-4">
+          <div className="text-4xl mb-4">{'\u{1F5FA}'}</div>
+          <h3 className="text-lg font-semibold text-app-text mb-2">No Map Data Available</h3>
+          <p className="text-app-text-muted text-sm mb-4">
+            Place data needs to be geocoded before it can be plotted on the map.
+            Click "Geocode Places" below to resolve place names to coordinates.
+          </p>
+          {mapData && (
+            <GeocodeProgressBar
+              ungeocoded={mapData.ungeocoded}
+              geocodeStats={mapData.geocodeStats}
+              dbId={dbId}
+              onComplete={onReload}
+            />
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="h-full flex flex-col">
+      {/* Geocode banner if there are ungeocoded places */}
+      {mapData.ungeocoded.length > 0 && (
+        <GeocodeProgressBar
+          ungeocoded={mapData.ungeocoded}
+          geocodeStats={mapData.geocodeStats}
+          dbId={dbId}
+          onComplete={onReload}
+        />
+      )}
+
+      {/* Controls bar */}
+      <div className="flex flex-wrap items-center gap-3 px-3 py-2 bg-app-card border-b border-app-border text-sm">
+        {/* Lineage toggles */}
+        <div className="flex items-center gap-2">
+          <label className="flex items-center gap-1 cursor-pointer">
+            <input
+              type="checkbox"
+              checked={showPaternal}
+              onChange={(e) => setShowPaternal(e.target.checked)}
+              className="accent-blue-500"
+            />
+            <span className="text-blue-400">Paternal</span>
+          </label>
+          <label className="flex items-center gap-1 cursor-pointer">
+            <input
+              type="checkbox"
+              checked={showMaternal}
+              onChange={(e) => setShowMaternal(e.target.checked)}
+              className="accent-red-500"
+            />
+            <span className="text-red-400">Maternal</span>
+          </label>
+        </div>
+
+        {/* Divider */}
+        <div className="w-px h-4 bg-app-border" />
+
+        {/* Time range slider */}
+        <div className="flex items-center gap-2 flex-1 min-w-[200px]">
+          <span className="text-app-text-muted whitespace-nowrap">{timeRange[0]}</span>
+          <input
+            type="range"
+            data-range="min"
+            min={yearRange.min}
+            max={yearRange.max}
+            value={timeRange[0]}
+            onChange={handleTimeChange}
+            className="flex-1 h-1 accent-blue-500"
+          />
+          <input
+            type="range"
+            data-range="max"
+            min={yearRange.min}
+            max={yearRange.max}
+            value={timeRange[1]}
+            onChange={handleTimeChange}
+            className="flex-1 h-1 accent-red-500"
+          />
+          <span className="text-app-text-muted whitespace-nowrap">{timeRange[1]}</span>
+        </div>
+
+        {/* Divider */}
+        <div className="w-px h-4 bg-app-border" />
+
+        {/* Theme toggle */}
+        <button
+          onClick={() => setIsDarkTheme(!isDarkTheme)}
+          className="px-2 py-1 rounded text-xs bg-app-bg border border-app-border hover:bg-app-hover"
+          title={isDarkTheme ? 'Switch to light map' : 'Switch to dark map'}
+        >
+          {isDarkTheme ? '\u{2600}' : '\u{1F319}'}
+        </button>
+
+        {/* Stats */}
+        <span className="text-app-text-muted text-xs">
+          {markersWithCoords} ancestors plotted
+        </span>
+      </div>
+
+      {/* Map */}
+      <div className="flex-1">
+        <MapContainer
+          center={[30, 0]}
+          zoom={3}
+          style={{ width: '100%', height: '100%' }}
+          ref={mapRef}
+        >
+          <TileLayer
+            key={isDarkTheme ? 'dark' : 'light'}
+            url={isDarkTheme ? DARK_TILES : LIGHT_TILES}
+            attribution={isDarkTheme ? DARK_ATTR : LIGHT_ATTR}
+          />
+
+          <FitBounds persons={filteredPersons} />
+
+          {/* Migration lines */}
+          {migrationLines.map((line, i) => (
+            <Polyline
+              key={`line-${i}`}
+              positions={[[line.from.lat, line.from.lng], [line.to.lat, line.to.lng]]}
+              pathOptions={getMigrationLineStyle(line.lineage)}
+            />
+          ))}
+
+          {/* Person markers - birth locations */}
+          {filteredPersons.map(person => {
+            const coords = person.birthCoords || person.deathCoords;
+            if (!coords) return null;
+            return (
+              <Marker
+                key={`marker-${person.id}`}
+                position={[coords.lat, coords.lng]}
+                icon={createPersonMarker(person)}
+              >
+                <Popup>
+                  <div dangerouslySetInnerHTML={{ __html: buildPopupHtml(person, dbId) }} />
+                </Popup>
+              </Marker>
+            );
+          })}
+        </MapContainer>
+      </div>
+    </div>
+  );
+}

--- a/client/src/components/ancestry-tree/views/MigrationMapView.tsx
+++ b/client/src/components/ancestry-tree/views/MigrationMapView.tsx
@@ -136,8 +136,8 @@ export function MigrationMapView({ mapData, dbId, loading, onReload }: Migration
     );
   }
 
-  // Empty state
-  if (!mapData || mapData.persons.length === 0) {
+  // Empty state - show when no persons have geocoded coordinates
+  if (!mapData || markersWithCoords === 0) {
     return (
       <div className="flex items-center justify-center h-full">
         <div className="text-center max-w-md px-4">

--- a/client/src/components/ancestry-tree/views/MigrationMapView.tsx
+++ b/client/src/components/ancestry-tree/views/MigrationMapView.tsx
@@ -151,7 +151,10 @@ export function MigrationMapView({ mapData, dbId, loading, onReload }: Migration
   const handleTimeChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
     const value = parseInt(e.target.value);
     const isMin = e.target.dataset.range === 'min';
-    setTimeRange(prev => isMin ? [value, prev[1]] : [prev[0], value]);
+    setTimeRange(prev => isMin
+      ? [value, Math.max(value, prev[1])]
+      : [Math.min(prev[0], value), value]
+    );
   }, []);
 
   if (loading) {
@@ -165,8 +168,9 @@ export function MigrationMapView({ mapData, dbId, loading, onReload }: Migration
     );
   }
 
-  // Empty state - show when no persons have geocoded coordinates
-  if (!mapData || markersWithCoords === 0) {
+  // Empty state - based on total data (not filtered) to avoid showing empty state from filters
+  const totalWithCoords = mapData ? mapData.persons.filter(p => p.birthCoords || p.deathCoords).length : 0;
+  if (!mapData || totalWithCoords === 0) {
     return (
       <div className="flex items-center justify-center h-full">
         <div className="text-center max-w-md px-4">

--- a/client/src/components/ancestry-tree/views/MigrationMapView.tsx
+++ b/client/src/components/ancestry-tree/views/MigrationMapView.tsx
@@ -60,7 +60,7 @@ function FitBounds({ persons }: { persons: MapPerson[] }) {
   useEffect(() => {
     const bounds = calculateBounds(persons);
     if (bounds) {
-      map.fitBounds(bounds as L.LatLngBoundsExpression, { padding: [40, 40], maxZoom: 8 });
+      map.fitBounds(bounds, { padding: [40, 40], maxZoom: 8 });
     }
   }, [map, persons]);
 

--- a/client/src/components/favorites/SparseTreeMapPage.tsx
+++ b/client/src/components/favorites/SparseTreeMapPage.tsx
@@ -1,0 +1,63 @@
+/**
+ * Sparse Tree Map Page
+ *
+ * Standalone page for viewing favorites plotted on a migration map.
+ * Accessible at /favorites/sparse-tree/:dbId/map
+ */
+
+import { useEffect, useState, useCallback } from 'react';
+import { useParams, Link } from 'react-router-dom';
+import type { MapData } from '@fsf/shared';
+import { api } from '../../services/api';
+import { MigrationMapView } from '../ancestry-tree/views/MigrationMapView';
+
+export function SparseTreeMapPage() {
+  const { dbId } = useParams<{ dbId: string }>();
+  const [mapData, setMapData] = useState<MapData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [dbName, setDbName] = useState<string>('');
+
+  const loadMapData = useCallback(async () => {
+    if (!dbId) return;
+    setLoading(true);
+    const [data, dbInfo] = await Promise.all([
+      api.getSparseTreeMapData(dbId),
+      api.getDatabase(dbId).catch(() => null),
+    ]);
+    setMapData(data);
+    if (dbInfo?.rootName) setDbName(dbInfo.rootName);
+    setLoading(false);
+  }, [dbId]);
+
+  useEffect(() => {
+    loadMapData();
+  }, [loadMapData]);
+
+  return (
+    <div className="h-full flex flex-col">
+      {/* Header */}
+      <div className="flex items-center gap-4 px-4 py-3 border-b border-app-border bg-app-card">
+        <Link
+          to={`/favorites/sparse-tree/${dbId}`}
+          className="text-app-text-muted hover:text-app-text text-sm"
+        >
+          {'\u{2190}'} Sparse Tree
+        </Link>
+        <h1 className="text-lg font-bold text-app-text">
+          {'\u{1F5FA}'} Favorites Migration Map
+        </h1>
+        {dbName && <span className="text-sm text-app-text-muted">{dbName}</span>}
+      </div>
+
+      {/* Map */}
+      <div className="flex-1">
+        <MigrationMapView
+          mapData={mapData}
+          dbId={dbId || ''}
+          loading={loading}
+          onReload={loadMapData}
+        />
+      </div>
+    </div>
+  );
+}

--- a/client/src/components/favorites/SparseTreeMapPage.tsx
+++ b/client/src/components/favorites/SparseTreeMapPage.tsx
@@ -21,7 +21,7 @@ export function SparseTreeMapPage() {
     if (!dbId) return;
     setLoading(true);
     const [data, dbInfo] = await Promise.all([
-      api.getSparseTreeMapData(dbId),
+      api.getSparseTreeMapData(dbId).catch(() => null),
       api.getDatabase(dbId).catch(() => null),
     ]);
     setMapData(data);

--- a/client/src/components/favorites/SparseTreePage.tsx
+++ b/client/src/components/favorites/SparseTreePage.tsx
@@ -607,6 +607,12 @@ export function SparseTreePage() {
           >
             All Favorites
           </Link>
+          <Link
+            to={`/favorites/sparse-tree/${dbId}/map`}
+            className="flex-1 sm:flex-initial px-3 py-2 min-h-[40px] flex items-center justify-center bg-app-border text-app-text-secondary rounded hover:bg-app-hover text-sm"
+          >
+            {'\u{1F5FA}'} Map
+          </Link>
           <button
             onClick={handleExportSvg}
             className="flex-1 sm:flex-initial px-3 py-2 min-h-[40px] bg-app-border text-app-text-secondary rounded hover:bg-app-hover text-sm flex items-center justify-center gap-1"

--- a/client/src/components/map/GeocodeProgressBar.tsx
+++ b/client/src/components/map/GeocodeProgressBar.tsx
@@ -5,11 +5,11 @@
  * batch geocoding via SSE. Uses EventSource (GET) for reliable streaming.
  */
 
-import { useState, useRef, useCallback } from 'react';
+import { useState, useRef, useCallback, useEffect } from 'react';
 
 interface GeocodeProgressBarProps {
   ungeocoded: string[];
-  geocodeStats: { resolved: number; pending: number; notFound: number; total: number };
+  geocodeStats: { resolved: number; pending: number; notFound: number; error: number; total: number };
   dbId: string;
   onComplete: () => void;
 }
@@ -69,11 +69,16 @@ export function GeocodeProgressBar({ ungeocoded, geocodeStats, dbId, onComplete 
     setProgress(null);
   }, []);
 
+  // Clean up EventSource on unmount
+  useEffect(() => () => {
+    eventSourceRef.current?.close();
+  }, []);
+
   if (ungeocoded.length === 0 && !isGeocoding) {
     return null;
   }
 
-  const pct = progress ? Math.round((progress.current / progress.total) * 100) : 0;
+  const pct = progress && progress.total > 0 ? Math.round((progress.current / progress.total) * 100) : 0;
 
   return (
     <div className="px-3 py-2 bg-amber-900/30 border-b border-amber-700/50">

--- a/client/src/components/map/GeocodeProgressBar.tsx
+++ b/client/src/components/map/GeocodeProgressBar.tsx
@@ -1,0 +1,123 @@
+/**
+ * Geocode Progress Bar
+ *
+ * Banner showing count of ungeocoded places with a button to trigger
+ * batch geocoding via SSE. Uses EventSource (GET) for reliable streaming.
+ */
+
+import { useState, useRef, useCallback } from 'react';
+
+interface GeocodeProgressBarProps {
+  ungeocoded: string[];
+  geocodeStats: { resolved: number; pending: number; notFound: number; total: number };
+  dbId: string;
+  onComplete: () => void;
+}
+
+interface ProgressState {
+  current: number;
+  total: number;
+  place?: string;
+  status?: string;
+}
+
+export function GeocodeProgressBar({ ungeocoded, geocodeStats, dbId, onComplete }: GeocodeProgressBarProps) {
+  const [isGeocoding, setIsGeocoding] = useState(false);
+  const [progress, setProgress] = useState<ProgressState | null>(null);
+  const eventSourceRef = useRef<EventSource | null>(null);
+
+  const startGeocoding = useCallback(() => {
+    setIsGeocoding(true);
+    setProgress({ current: 0, total: ungeocoded.length });
+
+    const es = new EventSource(`/api/map/geocode/stream?dbId=${encodeURIComponent(dbId)}`);
+    eventSourceRef.current = es;
+
+    es.onmessage = (event) => {
+      const data = JSON.parse(event.data);
+
+      if (data.type === 'progress') {
+        setProgress({ current: data.current, total: data.total, place: data.place, status: data.status });
+      }
+
+      if (data.type === 'complete') {
+        es.close();
+        eventSourceRef.current = null;
+        setIsGeocoding(false);
+        setProgress(null);
+        onComplete();
+      }
+    };
+
+    es.onerror = () => {
+      // EventSource will auto-reconnect on transient errors.
+      // If the stream has ended (server called res.end()), the readyState
+      // will be CLOSED and we should treat it as complete.
+      if (es.readyState === EventSource.CLOSED) {
+        eventSourceRef.current = null;
+        setIsGeocoding(false);
+        setProgress(null);
+        onComplete();
+      }
+    };
+  }, [ungeocoded, dbId, onComplete]);
+
+  const cancelGeocoding = useCallback(() => {
+    eventSourceRef.current?.close();
+    eventSourceRef.current = null;
+    setIsGeocoding(false);
+    setProgress(null);
+  }, []);
+
+  if (ungeocoded.length === 0 && !isGeocoding) {
+    return null;
+  }
+
+  const pct = progress ? Math.round((progress.current / progress.total) * 100) : 0;
+
+  return (
+    <div className="px-3 py-2 bg-amber-900/30 border-b border-amber-700/50">
+      {isGeocoding && progress ? (
+        <div className="flex items-center gap-3">
+          <div className="flex-1">
+            <div className="flex items-center justify-between text-xs text-amber-200 mb-1">
+              <span>Geocoding places... {progress.current}/{progress.total}</span>
+              <span>{pct}%</span>
+            </div>
+            <div className="w-full h-1.5 bg-amber-900/50 rounded-full overflow-hidden">
+              <div
+                className="h-full bg-amber-400 rounded-full transition-all duration-300"
+                style={{ width: `${pct}%` }}
+              />
+            </div>
+            {progress.place && (
+              <div className="text-xs text-amber-300/70 mt-1 truncate">
+                {progress.status === 'resolved' ? '\u{2705}' : progress.status === 'not_found' ? '\u{274C}' : '\u{23F3}'}{' '}
+                {progress.place}
+              </div>
+            )}
+          </div>
+          <button
+            onClick={cancelGeocoding}
+            className="px-2 py-1 text-xs bg-amber-800/50 text-amber-200 rounded hover:bg-amber-700/50"
+          >
+            Cancel
+          </button>
+        </div>
+      ) : (
+        <div className="flex items-center justify-between">
+          <span className="text-xs text-amber-200">
+            {'\u{1F4CD}'} {ungeocoded.length} place{ungeocoded.length !== 1 ? 's' : ''} need geocoding
+            {geocodeStats.resolved > 0 && ` (${geocodeStats.resolved} cached)`}
+          </span>
+          <button
+            onClick={startGeocoding}
+            className="px-3 py-1 text-xs bg-amber-600 text-white rounded hover:bg-amber-500 font-medium"
+          >
+            Geocode Places
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/client/src/components/map/GeocodeProgressBar.tsx
+++ b/client/src/components/map/GeocodeProgressBar.tsx
@@ -40,6 +40,14 @@ export function GeocodeProgressBar({ ungeocoded, geocodeStats, dbId, onComplete 
         setProgress({ current: data.current, total: data.total, place: data.place, status: data.status });
       }
 
+      if (data.type === 'error') {
+        es.close();
+        eventSourceRef.current = null;
+        setIsGeocoding(false);
+        setProgress(null);
+        onComplete();
+      }
+
       if (data.type === 'complete') {
         es.close();
         eventSourceRef.current = null;

--- a/client/src/components/map/mapUtils.ts
+++ b/client/src/components/map/mapUtils.ts
@@ -149,22 +149,16 @@ export function buildMigrationLines(persons: MapPerson[]): Array<{
 /**
  * Calculate bounds that encompass all person markers
  */
-export function calculateBounds(persons: MapPerson[]): L.LatLngBoundsExpression | null {
-  const coords: [number, number][] = [];
+export function calculateBounds(persons: MapPerson[]): L.LatLngBounds | null {
+  const points: L.LatLng[] = [];
 
   for (const person of persons) {
-    if (person.birthCoords) coords.push([person.birthCoords.lat, person.birthCoords.lng]);
-    if (person.deathCoords) coords.push([person.deathCoords.lat, person.deathCoords.lng]);
+    if (person.birthCoords) points.push(L.latLng(person.birthCoords.lat, person.birthCoords.lng));
+    if (person.deathCoords) points.push(L.latLng(person.deathCoords.lat, person.deathCoords.lng));
   }
 
-  if (coords.length === 0) return null;
-  if (coords.length === 1) {
-    // Single point - create bounds around it
-    return [
-      [coords[0][0] - 5, coords[0][1] - 5],
-      [coords[0][0] + 5, coords[0][1] + 5],
-    ];
-  }
+  if (points.length === 0) return null;
+  if (points.length === 1) return points[0].toBounds(500_000);
 
-  return coords as L.LatLngBoundsExpression;
+  return L.latLngBounds(points);
 }

--- a/client/src/components/map/mapUtils.ts
+++ b/client/src/components/map/mapUtils.ts
@@ -13,13 +13,6 @@ import { PATERNAL_COLORS, MATERNAL_COLORS } from '../ancestry-tree/utils/lineage
 const SELF_COLOR = '#A37FDB'; // Purple
 
 /**
- * Escape HTML special characters to prevent XSS
- */
-function escapeHtml(str: string): string {
-  return str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;').replace(/'/g, '&#x27;');
-}
-
-/**
  * Get the lineage color for a person
  */
 export function getPersonColor(person: MapPerson): string {
@@ -56,42 +49,6 @@ export function createPersonMarker(person: MapPerson): L.DivIcon {
     iconAnchor: [size / 2, size / 2],
     popupAnchor: [0, -size / 2 - 4],
   });
-}
-
-/**
- * Build popup HTML for a person marker
- */
-export function buildPopupHtml(person: MapPerson, dbId: string): string {
-  const name = escapeHtml(person.name);
-  const photoUrl = person.photoUrl ? escapeHtml(person.photoUrl) : '';
-  const photoHtml = photoUrl
-    ? `<img src="${photoUrl}" alt="${name}" style="width:48px;height:48px;border-radius:50%;object-fit:cover;margin-right:8px;float:left;" />`
-    : '';
-
-  const genderIcon = person.gender === 'male' ? '\u2642' : person.gender === 'female' ? '\u2640' : '';
-  const lineageLabel = person.lineage === 'paternal' ? 'Paternal' : person.lineage === 'maternal' ? 'Maternal' : '';
-  const favoriteLabel = person.isFavorite ? ' &#11088;' : '';
-  const lifespan = escapeHtml(person.lifespan);
-
-  const places: string[] = [];
-  if (person.birthPlace) places.push(`Born: ${escapeHtml(person.birthPlace)}`);
-  if (person.deathPlace) places.push(`Died: ${escapeHtml(person.deathPlace)}`);
-
-  return `
-    <div style="min-width:180px;max-width:280px;">
-      ${photoHtml}
-      <div>
-        <a href="/person/${encodeURIComponent(dbId)}/${encodeURIComponent(person.id)}" style="color:#4A90D9;font-weight:600;font-size:14px;text-decoration:none;">
-          ${name}${favoriteLabel}
-        </a>
-        <div style="color:#888;font-size:12px;margin-top:2px;">
-          ${genderIcon} ${lifespan}${lineageLabel ? ` &middot; ${lineageLabel}` : ''}${person.generation > 0 ? ` &middot; Gen ${person.generation}` : ''}
-        </div>
-        ${places.length > 0 ? `<div style="color:#aaa;font-size:11px;margin-top:4px;">${places.join('<br/>')}</div>` : ''}
-      </div>
-      <div style="clear:both;"></div>
-    </div>
-  `;
 }
 
 /**

--- a/client/src/components/map/mapUtils.ts
+++ b/client/src/components/map/mapUtils.ts
@@ -1,0 +1,153 @@
+/**
+ * Map Utilities
+ *
+ * Marker icon generators and migration line builders for the
+ * Leaflet-based migration map visualization.
+ */
+
+import L from 'leaflet';
+import type { MapPerson, MapCoords } from '@fsf/shared';
+import { PATERNAL_COLORS, MATERNAL_COLORS } from '../ancestry-tree/utils/lineageColors';
+
+// Self color (for root person)
+const SELF_COLOR = '#A37FDB'; // Purple
+
+/**
+ * Get the lineage color for a person
+ */
+export function getPersonColor(person: MapPerson): string {
+  if (person.lineage === 'self') return SELF_COLOR;
+  const colors = person.lineage === 'paternal' ? PATERNAL_COLORS : MATERNAL_COLORS;
+  const index = Math.min(person.generation - 1, colors.length - 1);
+  return colors[Math.max(0, index)];
+}
+
+/**
+ * Create a custom Leaflet divIcon marker for a person
+ */
+export function createPersonMarker(person: MapPerson): L.DivIcon {
+  const color = getPersonColor(person);
+  const size = person.generation === 0 ? 16 : Math.max(8, 14 - person.generation);
+  const borderWidth = person.isFavorite ? 3 : 2;
+  const starHtml = person.isFavorite ? '<span style="position:absolute;top:-8px;left:50%;transform:translateX(-50%);font-size:10px;">&#11088;</span>' : '';
+
+  return L.divIcon({
+    className: 'map-person-marker',
+    html: `<div style="position:relative;">
+      ${starHtml}
+      <div style="
+        width: ${size}px;
+        height: ${size}px;
+        border-radius: 50%;
+        background: ${color};
+        border: ${borderWidth}px solid ${person.generation === 0 ? '#fff' : 'rgba(255,255,255,0.7)'};
+        box-shadow: 0 1px 4px rgba(0,0,0,0.4);
+        cursor: pointer;
+      "></div>
+    </div>`,
+    iconSize: [size, size],
+    iconAnchor: [size / 2, size / 2],
+    popupAnchor: [0, -size / 2 - 4],
+  });
+}
+
+/**
+ * Build popup HTML for a person marker
+ */
+export function buildPopupHtml(person: MapPerson, dbId: string): string {
+  const photoHtml = person.photoUrl
+    ? `<img src="${person.photoUrl}" alt="${person.name}" style="width:48px;height:48px;border-radius:50%;object-fit:cover;margin-right:8px;float:left;" />`
+    : '';
+
+  const genderIcon = person.gender === 'male' ? '\u2642' : person.gender === 'female' ? '\u2640' : '';
+  const lineageLabel = person.lineage === 'paternal' ? 'Paternal' : person.lineage === 'maternal' ? 'Maternal' : '';
+  const favoriteLabel = person.isFavorite ? ' &#11088;' : '';
+
+  const places: string[] = [];
+  if (person.birthPlace) places.push(`Born: ${person.birthPlace}`);
+  if (person.deathPlace) places.push(`Died: ${person.deathPlace}`);
+
+  return `
+    <div style="min-width:180px;max-width:280px;">
+      ${photoHtml}
+      <div>
+        <a href="/person/${dbId}/${person.id}" style="color:#4A90D9;font-weight:600;font-size:14px;text-decoration:none;">
+          ${person.name}${favoriteLabel}
+        </a>
+        <div style="color:#888;font-size:12px;margin-top:2px;">
+          ${genderIcon} ${person.lifespan}${lineageLabel ? ` &middot; ${lineageLabel}` : ''}${person.generation > 0 ? ` &middot; Gen ${person.generation}` : ''}
+        </div>
+        ${places.length > 0 ? `<div style="color:#aaa;font-size:11px;margin-top:4px;">${places.join('<br/>')}</div>` : ''}
+      </div>
+      <div style="clear:both;"></div>
+    </div>
+  `;
+}
+
+/**
+ * Migration line style based on lineage
+ */
+export function getMigrationLineStyle(lineage: 'paternal' | 'maternal' | 'self'): L.PolylineOptions {
+  const color = lineage === 'paternal' ? PATERNAL_COLORS[0]
+    : lineage === 'maternal' ? MATERNAL_COLORS[0]
+    : SELF_COLOR;
+
+  return {
+    color,
+    weight: 1.5,
+    opacity: 0.5,
+    dashArray: '4 4',
+  };
+}
+
+/**
+ * Build migration lines connecting parent birth locations to child birth locations
+ */
+export function buildMigrationLines(persons: MapPerson[]): Array<{
+  from: MapCoords;
+  to: MapCoords;
+  lineage: 'paternal' | 'maternal' | 'self';
+}> {
+  const lines: Array<{ from: MapCoords; to: MapCoords; lineage: 'paternal' | 'maternal' | 'self' }> = [];
+  const personMap = new Map(persons.map(p => [p.id, p]));
+
+  for (const person of persons) {
+    if (!person.parentId || !person.birthCoords) continue;
+    const parent = personMap.get(person.parentId);
+    if (!parent?.birthCoords) continue;
+
+    // Don't draw line if parent and child born in same location
+    if (parent.birthCoords.lat === person.birthCoords.lat && parent.birthCoords.lng === person.birthCoords.lng) continue;
+
+    lines.push({
+      from: parent.birthCoords,
+      to: person.birthCoords,
+      lineage: person.lineage,
+    });
+  }
+
+  return lines;
+}
+
+/**
+ * Calculate bounds that encompass all person markers
+ */
+export function calculateBounds(persons: MapPerson[]): L.LatLngBoundsExpression | null {
+  const coords: [number, number][] = [];
+
+  for (const person of persons) {
+    if (person.birthCoords) coords.push([person.birthCoords.lat, person.birthCoords.lng]);
+    if (person.deathCoords) coords.push([person.deathCoords.lat, person.deathCoords.lng]);
+  }
+
+  if (coords.length === 0) return null;
+  if (coords.length === 1) {
+    // Single point - create bounds around it
+    return [
+      [coords[0][0] - 5, coords[0][1] - 5],
+      [coords[0][0] + 5, coords[0][1] + 5],
+    ];
+  }
+
+  return coords as L.LatLngBoundsExpression;
+}

--- a/client/src/components/map/mapUtils.ts
+++ b/client/src/components/map/mapUtils.ts
@@ -13,6 +13,13 @@ import { PATERNAL_COLORS, MATERNAL_COLORS } from '../ancestry-tree/utils/lineage
 const SELF_COLOR = '#A37FDB'; // Purple
 
 /**
+ * Escape HTML special characters to prevent XSS
+ */
+function escapeHtml(str: string): string {
+  return str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;').replace(/'/g, '&#x27;');
+}
+
+/**
  * Get the lineage color for a person
  */
 export function getPersonColor(person: MapPerson): string {
@@ -55,27 +62,30 @@ export function createPersonMarker(person: MapPerson): L.DivIcon {
  * Build popup HTML for a person marker
  */
 export function buildPopupHtml(person: MapPerson, dbId: string): string {
-  const photoHtml = person.photoUrl
-    ? `<img src="${person.photoUrl}" alt="${person.name}" style="width:48px;height:48px;border-radius:50%;object-fit:cover;margin-right:8px;float:left;" />`
+  const name = escapeHtml(person.name);
+  const photoUrl = person.photoUrl ? escapeHtml(person.photoUrl) : '';
+  const photoHtml = photoUrl
+    ? `<img src="${photoUrl}" alt="${name}" style="width:48px;height:48px;border-radius:50%;object-fit:cover;margin-right:8px;float:left;" />`
     : '';
 
   const genderIcon = person.gender === 'male' ? '\u2642' : person.gender === 'female' ? '\u2640' : '';
   const lineageLabel = person.lineage === 'paternal' ? 'Paternal' : person.lineage === 'maternal' ? 'Maternal' : '';
   const favoriteLabel = person.isFavorite ? ' &#11088;' : '';
+  const lifespan = escapeHtml(person.lifespan);
 
   const places: string[] = [];
-  if (person.birthPlace) places.push(`Born: ${person.birthPlace}`);
-  if (person.deathPlace) places.push(`Died: ${person.deathPlace}`);
+  if (person.birthPlace) places.push(`Born: ${escapeHtml(person.birthPlace)}`);
+  if (person.deathPlace) places.push(`Died: ${escapeHtml(person.deathPlace)}`);
 
   return `
     <div style="min-width:180px;max-width:280px;">
       ${photoHtml}
       <div>
-        <a href="/person/${dbId}/${person.id}" style="color:#4A90D9;font-weight:600;font-size:14px;text-decoration:none;">
-          ${person.name}${favoriteLabel}
+        <a href="/person/${encodeURIComponent(dbId)}/${encodeURIComponent(person.id)}" style="color:#4A90D9;font-weight:600;font-size:14px;text-decoration:none;">
+          ${name}${favoriteLabel}
         </a>
         <div style="color:#888;font-size:12px;margin-top:2px;">
-          ${genderIcon} ${person.lifespan}${lineageLabel ? ` &middot; ${lineageLabel}` : ''}${person.generation > 0 ? ` &middot; Gen ${person.generation}` : ''}
+          ${genderIcon} ${lifespan}${lineageLabel ? ` &middot; ${lineageLabel}` : ''}${person.generation > 0 ? ` &middot; Gen ${person.generation}` : ''}
         </div>
         ${places.length > 0 ? `<div style="color:#aaa;font-size:11px;margin-top:4px;">${places.join('<br/>')}</div>` : ''}
       </div>

--- a/client/src/services/api.ts
+++ b/client/src/services/api.ts
@@ -722,11 +722,19 @@ export const api = {
       body: JSON.stringify({ personId, whyInteresting, tags })
     }),
 
-  applyDiscoveryBatch: (dbId: string, candidates: DiscoveryCandidate[]) =>
-    fetchJson<{ applied: number }>(`/ai-discovery/${dbId}/apply-batch`, {
-      method: 'POST',
-      body: JSON.stringify({ candidates })
-    }),
+  applyDiscoveryBatch: async (dbId: string, candidates: DiscoveryCandidate[]): Promise<{ applied: number }> => {
+    const CHUNK_SIZE = 1000;
+    let totalApplied = 0;
+    for (let i = 0; i < candidates.length; i += CHUNK_SIZE) {
+      const chunk = candidates.slice(i, i + CHUNK_SIZE);
+      const result = await fetchJson<{ applied: number }>(`/ai-discovery/${dbId}/apply-batch`, {
+        method: 'POST',
+        body: JSON.stringify({ candidates: chunk })
+      });
+      totalApplied += result.applied;
+    }
+    return { applied: totalApplied };
+  },
 
   dismissDiscoveryCandidate: (dbId: string, personId: string, whyInteresting?: string, suggestedTags?: string[]) =>
     fetchJson<{ success: boolean }>(`/ai-discovery/${dbId}/dismiss`, {
@@ -734,11 +742,19 @@ export const api = {
       body: JSON.stringify({ personId, whyInteresting, suggestedTags })
     }),
 
-  dismissDiscoveryBatch: (dbId: string, candidates: Array<{ personId: string; whyInteresting?: string; suggestedTags?: string[] }>) =>
-    fetchJson<{ dismissed: number }>(`/ai-discovery/${dbId}/dismiss-batch`, {
-      method: 'POST',
-      body: JSON.stringify({ candidates })
-    }),
+  dismissDiscoveryBatch: async (dbId: string, candidates: Array<{ personId: string; whyInteresting?: string; suggestedTags?: string[] }>): Promise<{ dismissed: number }> => {
+    const CHUNK_SIZE = 1000;
+    let totalDismissed = 0;
+    for (let i = 0; i < candidates.length; i += CHUNK_SIZE) {
+      const chunk = candidates.slice(i, i + CHUNK_SIZE);
+      const result = await fetchJson<{ dismissed: number }>(`/ai-discovery/${dbId}/dismiss-batch`, {
+        method: 'POST',
+        body: JSON.stringify({ candidates: chunk })
+      });
+      totalDismissed += result.dismissed;
+    }
+    return { dismissed: totalDismissed };
+  },
 
   getDismissedCandidates: (dbId: string) =>
     fetchJson<{ dismissed: DismissedCandidate[]; count: number }>(`/ai-discovery/${dbId}/dismissed`),

--- a/client/src/services/api.ts
+++ b/client/src/services/api.ts
@@ -839,7 +839,7 @@ export const api = {
     fetchJson<MapData>(`/map/${dbId}/sparse`),
 
   getGeocodeStats: () =>
-    fetchJson<{ resolved: number; pending: number; notFound: number; total: number }>('/map/geocode/stats'),
+    fetchJson<{ resolved: number; pending: number; notFound: number; error: number; total: number }>('/map/geocode/stats'),
 };
 
 // Test Runner types

--- a/client/src/services/api.ts
+++ b/client/src/services/api.ts
@@ -700,7 +700,7 @@ export const api = {
 
 
   // AI Discovery
-  quickDiscovery: (dbId: string, sampleSize = 100, options?: { model?: string; excludeBiblical?: boolean; minBirthYear?: number; customPrompt?: string }) =>
+  quickDiscovery: (dbId: string, sampleSize = 100, options?: { model?: string; excludeBiblical?: boolean; minBirthYear?: number; maxGenerations?: number; customPrompt?: string }) =>
     fetchJson<DiscoveryResult>(`/ai-discovery/${dbId}/quick`, {
       method: 'POST',
       body: JSON.stringify({ sampleSize, ...options })
@@ -725,6 +725,31 @@ export const api = {
     fetchJson<{ applied: number }>(`/ai-discovery/${dbId}/apply-batch`, {
       method: 'POST',
       body: JSON.stringify({ candidates })
+    }),
+
+  dismissDiscoveryCandidate: (dbId: string, personId: string, whyInteresting?: string, suggestedTags?: string[]) =>
+    fetchJson<{ success: boolean }>(`/ai-discovery/${dbId}/dismiss`, {
+      method: 'POST',
+      body: JSON.stringify({ personId, whyInteresting, suggestedTags })
+    }),
+
+  dismissDiscoveryBatch: (dbId: string, candidates: Array<{ personId: string; whyInteresting?: string; suggestedTags?: string[] }>) =>
+    fetchJson<{ dismissed: number }>(`/ai-discovery/${dbId}/dismiss-batch`, {
+      method: 'POST',
+      body: JSON.stringify({ candidates })
+    }),
+
+  getDismissedCandidates: (dbId: string) =>
+    fetchJson<{ dismissed: DismissedCandidate[]; count: number }>(`/ai-discovery/${dbId}/dismissed`),
+
+  undoDismissCandidate: (dbId: string, personId: string) =>
+    fetchJson<{ success: boolean }>(`/ai-discovery/${dbId}/dismissed/${personId}`, {
+      method: 'DELETE'
+    }),
+
+  clearDismissedCandidates: (dbId: string) =>
+    fetchJson<{ cleared: number }>(`/ai-discovery/${dbId}/dismissed`, {
+      method: 'DELETE'
     }),
 
   // Test Runner
@@ -863,6 +888,13 @@ export interface DiscoveryProgress {
   currentBatch: number;
   totalBatches: number;
   error?: string;
+}
+
+export interface DismissedCandidate {
+  personId: string;
+  aiReason: string | null;
+  aiTags: string[];
+  dismissedAt: string;
 }
 
 // FamilySearch sync result

--- a/client/src/services/api.ts
+++ b/client/src/services/api.ts
@@ -35,6 +35,7 @@ import type {
   StaleRecord,
   AncestryHintResult,
   AncestryUpdateStatus,
+  MapData,
 } from '@fsf/shared';
 
 const BASE_URL = '/api';
@@ -829,6 +830,16 @@ export const api = {
     fetchJson<{ valid: boolean; hasAncestryLink: boolean; personName: string }>(
       `/ancestry-update/${dbId}/validate/${personId}`
     ),
+
+  // Migration Map
+  getAncestryMapData: (dbId: string, personId: string, depth = 8) =>
+    fetchJson<MapData>(`/map/${dbId}/${personId}?depth=${depth}`),
+
+  getSparseTreeMapData: (dbId: string) =>
+    fetchJson<MapData>(`/map/${dbId}/sparse`),
+
+  getGeocodeStats: () =>
+    fetchJson<{ resolved: number; pending: number; notFound: number; total: number }>('/map/geocode/stats'),
 };
 
 // Test Runner types
@@ -1089,4 +1100,8 @@ export type {
   AncestryHintProgress,
   AncestryUpdateProgress,
   AncestryUpdateStatus,
+  MapData,
+  MapPerson,
+  MapCoords,
+  GeocodeProgress,
 } from '@fsf/shared';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sparsetree",
-  "version": "0.6.33",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sparsetree",
-      "version": "0.6.33",
+      "version": "0.7.0",
       "license": "ISC",
       "workspaces": [
         "shared",
@@ -59,7 +59,7 @@
     },
     "client": {
       "name": "@fsf/client",
-      "version": "0.6.33",
+      "version": "0.7.0",
       "dependencies": {
         "@fsf/shared": "*",
         "d3": "^7.9.0",
@@ -8360,7 +8360,7 @@
     },
     "server": {
       "name": "@fsf/server",
-      "version": "0.6.33",
+      "version": "0.7.0",
       "dependencies": {
         "@fsf/shared": "*",
         "better-sqlite3": "^12.6.2",
@@ -8383,7 +8383,7 @@
     },
     "shared": {
       "name": "@fsf/shared",
-      "version": "0.6.33",
+      "version": "0.7.0",
       "devDependencies": {
         "typescript": "^5.7.2"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sparsetree",
-  "version": "0.7.8",
+  "version": "0.7.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sparsetree",
-      "version": "0.7.8",
+      "version": "0.7.9",
       "license": "ISC",
       "workspaces": [
         "shared",
@@ -59,7 +59,7 @@
     },
     "client": {
       "name": "@fsf/client",
-      "version": "0.7.8",
+      "version": "0.7.9",
       "dependencies": {
         "@fsf/shared": "*",
         "d3": "^7.9.0",
@@ -8404,7 +8404,7 @@
     },
     "server": {
       "name": "@fsf/server",
-      "version": "0.7.8",
+      "version": "0.7.9",
       "dependencies": {
         "@fsf/shared": "*",
         "better-sqlite3": "^12.6.2",
@@ -8427,7 +8427,7 @@
     },
     "shared": {
       "name": "@fsf/shared",
-      "version": "0.7.8",
+      "version": "0.7.9",
       "devDependencies": {
         "typescript": "^5.7.2"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sparsetree",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sparsetree",
-      "version": "0.7.3",
+      "version": "0.7.4",
       "license": "ISC",
       "workspaces": [
         "shared",
@@ -59,7 +59,7 @@
     },
     "client": {
       "name": "@fsf/client",
-      "version": "0.7.3",
+      "version": "0.7.4",
       "dependencies": {
         "@fsf/shared": "*",
         "d3": "^7.9.0",
@@ -8404,7 +8404,7 @@
     },
     "server": {
       "name": "@fsf/server",
-      "version": "0.7.3",
+      "version": "0.7.4",
       "dependencies": {
         "@fsf/shared": "*",
         "better-sqlite3": "^12.6.2",
@@ -8427,7 +8427,7 @@
     },
     "shared": {
       "name": "@fsf/shared",
-      "version": "0.7.3",
+      "version": "0.7.4",
       "devDependencies": {
         "typescript": "^5.7.2"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sparsetree",
-  "version": "0.7.7",
+  "version": "0.7.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sparsetree",
-      "version": "0.7.7",
+      "version": "0.7.8",
       "license": "ISC",
       "workspaces": [
         "shared",
@@ -59,7 +59,7 @@
     },
     "client": {
       "name": "@fsf/client",
-      "version": "0.7.7",
+      "version": "0.7.8",
       "dependencies": {
         "@fsf/shared": "*",
         "d3": "^7.9.0",
@@ -8404,7 +8404,7 @@
     },
     "server": {
       "name": "@fsf/server",
-      "version": "0.7.7",
+      "version": "0.7.8",
       "dependencies": {
         "@fsf/shared": "*",
         "better-sqlite3": "^12.6.2",
@@ -8427,7 +8427,7 @@
     },
     "shared": {
       "name": "@fsf/shared",
-      "version": "0.7.7",
+      "version": "0.7.8",
       "devDependencies": {
         "typescript": "^5.7.2"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sparsetree",
-  "version": "0.7.9",
+  "version": "0.7.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sparsetree",
-      "version": "0.7.9",
+      "version": "0.7.10",
       "license": "ISC",
       "workspaces": [
         "shared",
@@ -59,7 +59,7 @@
     },
     "client": {
       "name": "@fsf/client",
-      "version": "0.7.9",
+      "version": "0.7.10",
       "dependencies": {
         "@fsf/shared": "*",
         "d3": "^7.9.0",
@@ -8404,7 +8404,7 @@
     },
     "server": {
       "name": "@fsf/server",
-      "version": "0.7.9",
+      "version": "0.7.10",
       "dependencies": {
         "@fsf/shared": "*",
         "better-sqlite3": "^12.6.2",
@@ -8427,7 +8427,7 @@
     },
     "shared": {
       "name": "@fsf/shared",
-      "version": "0.7.9",
+      "version": "0.7.10",
       "devDependencies": {
         "typescript": "^5.7.2"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sparsetree",
-  "version": "0.7.11",
+  "version": "0.7.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sparsetree",
-      "version": "0.7.11",
+      "version": "0.7.12",
       "license": "ISC",
       "workspaces": [
         "shared",
@@ -59,7 +59,7 @@
     },
     "client": {
       "name": "@fsf/client",
-      "version": "0.7.11",
+      "version": "0.7.12",
       "dependencies": {
         "@fsf/shared": "*",
         "d3": "^7.9.0",
@@ -8404,7 +8404,7 @@
     },
     "server": {
       "name": "@fsf/server",
-      "version": "0.7.11",
+      "version": "0.7.12",
       "dependencies": {
         "@fsf/shared": "*",
         "better-sqlite3": "^12.6.2",
@@ -8427,7 +8427,7 @@
     },
     "shared": {
       "name": "@fsf/shared",
-      "version": "0.7.11",
+      "version": "0.7.12",
       "devDependencies": {
         "typescript": "^5.7.2"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sparsetree",
-  "version": "0.7.5",
+  "version": "0.7.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sparsetree",
-      "version": "0.7.5",
+      "version": "0.7.6",
       "license": "ISC",
       "workspaces": [
         "shared",
@@ -59,7 +59,7 @@
     },
     "client": {
       "name": "@fsf/client",
-      "version": "0.7.5",
+      "version": "0.7.6",
       "dependencies": {
         "@fsf/shared": "*",
         "d3": "^7.9.0",
@@ -8404,7 +8404,7 @@
     },
     "server": {
       "name": "@fsf/server",
-      "version": "0.7.5",
+      "version": "0.7.6",
       "dependencies": {
         "@fsf/shared": "*",
         "better-sqlite3": "^12.6.2",
@@ -8427,7 +8427,7 @@
     },
     "shared": {
       "name": "@fsf/shared",
-      "version": "0.7.5",
+      "version": "0.7.6",
       "devDependencies": {
         "typescript": "^5.7.2"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sparsetree",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sparsetree",
-      "version": "0.7.1",
+      "version": "0.7.2",
       "license": "ISC",
       "workspaces": [
         "shared",
@@ -59,7 +59,7 @@
     },
     "client": {
       "name": "@fsf/client",
-      "version": "0.7.1",
+      "version": "0.7.2",
       "dependencies": {
         "@fsf/shared": "*",
         "d3": "^7.9.0",
@@ -145,7 +145,6 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -1628,7 +1627,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -2123,7 +2123,6 @@
       "integrity": "sha512-cisd7gxkzjBKU2GgdYrTdtQx1SORymWyaAFhaxQPK9bYO9ot3Y5OikQRvY0VYQtvwjeQnizCINJAenh/V7MK2w==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -2462,6 +2461,7 @@
       "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "dequal": "^2.0.3"
       }
@@ -2789,7 +2789,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3218,8 +3217,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/d3": {
       "version": "7.9.0",
@@ -3538,7 +3536,6 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -3717,6 +3714,7 @@
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -3770,7 +3768,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -4503,7 +4502,6 @@
       "integrity": "sha512-n0QrmT9lD81rbpKsyhnlz3DgnMZlaOkJPpgi746doA+HvaMC79bdWkwjrNnGJRvDrWTI8iOcJiVTJ5CdT/AZRw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "webidl-conversions": "^7.0.0",
         "whatwg-mimetype": "^3.0.0"
@@ -4876,7 +4874,6 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -4956,8 +4953,7 @@
       "version": "1.9.4",
       "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
       "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==",
-      "license": "BSD-2-Clause",
-      "peer": true
+      "license": "BSD-2-Clause"
     },
     "node_modules/lilconfig": {
       "version": "3.1.3",
@@ -5028,6 +5024,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -5708,7 +5705,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -5884,6 +5880,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -5899,6 +5896,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -6027,7 +6025,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -6040,7 +6037,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -6071,7 +6067,8 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-leaflet": {
       "version": "4.2.1",
@@ -7180,7 +7177,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7499,7 +7495,6 @@
       "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -8100,7 +8095,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -8114,7 +8108,6 @@
       "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.4",
@@ -8411,7 +8404,7 @@
     },
     "server": {
       "name": "@fsf/server",
-      "version": "0.7.1",
+      "version": "0.7.2",
       "dependencies": {
         "@fsf/shared": "*",
         "better-sqlite3": "^12.6.2",
@@ -8434,7 +8427,7 @@
     },
     "shared": {
       "name": "@fsf/shared",
-      "version": "0.7.1",
+      "version": "0.7.2",
       "devDependencies": {
         "typescript": "^5.7.2"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sparsetree",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sparsetree",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "license": "ISC",
       "workspaces": [
         "shared",
@@ -59,7 +59,7 @@
     },
     "client": {
       "name": "@fsf/client",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "dependencies": {
         "@fsf/shared": "*",
         "d3": "^7.9.0",
@@ -8360,7 +8360,7 @@
     },
     "server": {
       "name": "@fsf/server",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "dependencies": {
         "@fsf/shared": "*",
         "better-sqlite3": "^12.6.2",
@@ -8383,7 +8383,7 @@
     },
     "shared": {
       "name": "@fsf/shared",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "devDependencies": {
         "typescript": "^5.7.2"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sparsetree",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sparsetree",
-      "version": "0.7.6",
+      "version": "0.7.7",
       "license": "ISC",
       "workspaces": [
         "shared",
@@ -59,7 +59,7 @@
     },
     "client": {
       "name": "@fsf/client",
-      "version": "0.7.6",
+      "version": "0.7.7",
       "dependencies": {
         "@fsf/shared": "*",
         "d3": "^7.9.0",
@@ -8404,7 +8404,7 @@
     },
     "server": {
       "name": "@fsf/server",
-      "version": "0.7.6",
+      "version": "0.7.7",
       "dependencies": {
         "@fsf/shared": "*",
         "better-sqlite3": "^12.6.2",
@@ -8427,7 +8427,7 @@
     },
     "shared": {
       "name": "@fsf/shared",
-      "version": "0.7.6",
+      "version": "0.7.7",
       "devDependencies": {
         "typescript": "^5.7.2"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sparsetree",
-  "version": "0.7.10",
+  "version": "0.7.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sparsetree",
-      "version": "0.7.10",
+      "version": "0.7.11",
       "license": "ISC",
       "workspaces": [
         "shared",
@@ -59,7 +59,7 @@
     },
     "client": {
       "name": "@fsf/client",
-      "version": "0.7.10",
+      "version": "0.7.11",
       "dependencies": {
         "@fsf/shared": "*",
         "d3": "^7.9.0",
@@ -8404,7 +8404,7 @@
     },
     "server": {
       "name": "@fsf/server",
-      "version": "0.7.10",
+      "version": "0.7.11",
       "dependencies": {
         "@fsf/shared": "*",
         "better-sqlite3": "^12.6.2",
@@ -8427,7 +8427,7 @@
     },
     "shared": {
       "name": "@fsf/shared",
-      "version": "0.7.10",
+      "version": "0.7.11",
       "devDependencies": {
         "typescript": "^5.7.2"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,17 +63,20 @@
       "dependencies": {
         "@fsf/shared": "*",
         "d3": "^7.9.0",
+        "leaflet": "^1.9.4",
         "lucide-react": "^0.562.0",
         "portos-ai-toolkit": "^0.1.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-hot-toast": "^2.6.0",
+        "react-leaflet": "^4.2.1",
         "react-router-dom": "^7.1.1",
         "socket.io-client": "^4.8.3",
         "zustand": "^5.0.2"
       },
       "devDependencies": {
         "@types/d3": "^7.4.3",
+        "@types/leaflet": "^1.9.21",
         "@types/react": "^18.3.18",
         "@types/react-dom": "^18.3.5",
         "@vitejs/plugin-react": "^4.3.4",
@@ -142,6 +145,7 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -1238,6 +1242,17 @@
         "node": ">=18"
       }
     },
+    "node_modules/@react-leaflet/core": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@react-leaflet/core/-/core-2.1.0.tgz",
+      "integrity": "sha512-Qk7Pfu8BSarKGqILj4x7bCSZ1pjuAPZ+qmRwH5S7mDS91VSbVVsJSrW4qA+GPrro8t69gFYVMWb1Zc4yFmPiVg==",
+      "license": "Hippocratic-2.1",
+      "peerDependencies": {
+        "leaflet": "^1.9.0",
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.27",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
@@ -1613,8 +1628,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -2056,6 +2070,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/leaflet": {
+      "version": "1.9.21",
+      "resolved": "https://registry.npmjs.org/@types/leaflet/-/leaflet-1.9.21.tgz",
+      "integrity": "sha512-TbAd9DaPGSnzp6QvtYngntMZgcRk+igFELwR2N99XZn7RXUdKgsXMR+28bUO0rPsWp8MIu/f47luLIQuSLYv/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
+    },
     "node_modules/@types/methods": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/@types/methods/-/methods-1.1.4.tgz",
@@ -2099,6 +2123,7 @@
       "integrity": "sha512-cisd7gxkzjBKU2GgdYrTdtQx1SORymWyaAFhaxQPK9bYO9ot3Y5OikQRvY0VYQtvwjeQnizCINJAenh/V7MK2w==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -2437,7 +2462,6 @@
       "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "dequal": "^2.0.3"
       }
@@ -2765,6 +2789,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3193,7 +3218,8 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/d3": {
       "version": "7.9.0",
@@ -3512,6 +3538,7 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -3690,7 +3717,6 @@
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -3744,8 +3770,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -4478,6 +4503,7 @@
       "integrity": "sha512-n0QrmT9lD81rbpKsyhnlz3DgnMZlaOkJPpgi746doA+HvaMC79bdWkwjrNnGJRvDrWTI8iOcJiVTJ5CdT/AZRw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "webidl-conversions": "^7.0.0",
         "whatwg-mimetype": "^3.0.0"
@@ -4850,6 +4876,7 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -4925,6 +4952,13 @@
         "node": ">=0.6.0"
       }
     },
+    "node_modules/leaflet": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
+      "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==",
+      "license": "BSD-2-Clause",
+      "peer": true
+    },
     "node_modules/lilconfig": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
@@ -4994,7 +5028,6 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -5675,6 +5708,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -5850,7 +5884,6 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -5866,7 +5899,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -5995,6 +6027,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -6007,6 +6040,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -6037,8 +6071,21 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
+    },
+    "node_modules/react-leaflet": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/react-leaflet/-/react-leaflet-4.2.1.tgz",
+      "integrity": "sha512-p9chkvhcKrWn/H/1FFeVSqLdReGwn2qmiobOQGO3BifX+/vV/39qhY8dGqbdcPh1e6jxh/QHriLXr7a4eLFK4Q==",
+      "license": "Hippocratic-2.1",
+      "dependencies": {
+        "@react-leaflet/core": "^2.1.0"
+      },
+      "peerDependencies": {
+        "leaflet": "^1.9.0",
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
     },
     "node_modules/react-refresh": {
       "version": "0.17.0",
@@ -7133,6 +7180,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7451,6 +7499,7 @@
       "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -8051,6 +8100,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -8064,6 +8114,7 @@
       "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sparsetree",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sparsetree",
-      "version": "0.7.4",
+      "version": "0.7.5",
       "license": "ISC",
       "workspaces": [
         "shared",
@@ -59,7 +59,7 @@
     },
     "client": {
       "name": "@fsf/client",
-      "version": "0.7.4",
+      "version": "0.7.5",
       "dependencies": {
         "@fsf/shared": "*",
         "d3": "^7.9.0",
@@ -8404,7 +8404,7 @@
     },
     "server": {
       "name": "@fsf/server",
-      "version": "0.7.4",
+      "version": "0.7.5",
       "dependencies": {
         "@fsf/shared": "*",
         "better-sqlite3": "^12.6.2",
@@ -8427,7 +8427,7 @@
     },
     "shared": {
       "name": "@fsf/shared",
-      "version": "0.7.4",
+      "version": "0.7.5",
       "devDependencies": {
         "typescript": "^5.7.2"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sparsetree",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sparsetree",
-      "version": "0.7.2",
+      "version": "0.7.3",
       "license": "ISC",
       "workspaces": [
         "shared",
@@ -59,7 +59,7 @@
     },
     "client": {
       "name": "@fsf/client",
-      "version": "0.7.2",
+      "version": "0.7.3",
       "dependencies": {
         "@fsf/shared": "*",
         "d3": "^7.9.0",
@@ -8404,7 +8404,7 @@
     },
     "server": {
       "name": "@fsf/server",
-      "version": "0.7.2",
+      "version": "0.7.3",
       "dependencies": {
         "@fsf/shared": "*",
         "better-sqlite3": "^12.6.2",
@@ -8427,7 +8427,7 @@
     },
     "shared": {
       "name": "@fsf/shared",
-      "version": "0.7.2",
+      "version": "0.7.3",
       "devDependencies": {
         "typescript": "^5.7.2"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sparsetree",
-  "version": "0.7.7",
+  "version": "0.7.8",
   "private": true,
   "description": "",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sparsetree",
-  "version": "0.6.33",
+  "version": "0.7.0",
   "private": true,
   "description": "",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sparsetree",
-  "version": "0.7.8",
+  "version": "0.7.9",
   "private": true,
   "description": "",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sparsetree",
-  "version": "0.7.10",
+  "version": "0.7.11",
   "private": true,
   "description": "",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sparsetree",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "private": true,
   "description": "",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sparsetree",
-  "version": "0.7.5",
+  "version": "0.7.6",
   "private": true,
   "description": "",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sparsetree",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "private": true,
   "description": "",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sparsetree",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "private": true,
   "description": "",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sparsetree",
-  "version": "0.7.11",
+  "version": "0.7.12",
   "private": true,
   "description": "",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sparsetree",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "private": true,
   "description": "",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sparsetree",
-  "version": "0.7.9",
+  "version": "0.7.10",
   "private": true,
   "description": "",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sparsetree",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "private": true,
   "description": "",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sparsetree",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "private": true,
   "description": "",
   "main": "index.js",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fsf/server",
-  "version": "0.7.7",
+  "version": "0.7.8",
   "type": "module",
   "main": "dist/index.js",
   "scripts": {

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fsf/server",
-  "version": "0.7.10",
+  "version": "0.7.11",
   "type": "module",
   "main": "dist/index.js",
   "scripts": {

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fsf/server",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "type": "module",
   "main": "dist/index.js",
   "scripts": {

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fsf/server",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "type": "module",
   "main": "dist/index.js",
   "scripts": {

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fsf/server",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "type": "module",
   "main": "dist/index.js",
   "scripts": {

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fsf/server",
-  "version": "0.7.5",
+  "version": "0.7.6",
   "type": "module",
   "main": "dist/index.js",
   "scripts": {

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fsf/server",
-  "version": "0.7.11",
+  "version": "0.7.12",
   "type": "module",
   "main": "dist/index.js",
   "scripts": {

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fsf/server",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "type": "module",
   "main": "dist/index.js",
   "scripts": {

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fsf/server",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "type": "module",
   "main": "dist/index.js",
   "scripts": {

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fsf/server",
-  "version": "0.7.8",
+  "version": "0.7.9",
   "type": "module",
   "main": "dist/index.js",
   "scripts": {

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fsf/server",
-  "version": "0.6.33",
+  "version": "0.7.0",
   "type": "module",
   "main": "dist/index.js",
   "scripts": {

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fsf/server",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "type": "module",
   "main": "dist/index.js",
   "scripts": {

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fsf/server",
-  "version": "0.7.9",
+  "version": "0.7.10",
   "type": "module",
   "main": "dist/index.js",
   "scripts": {

--- a/server/src/db/migrations/005_discovery_dismissed.ts
+++ b/server/src/db/migrations/005_discovery_dismissed.ts
@@ -1,0 +1,40 @@
+/**
+ * Migration 005: Add discovery_dismissed table
+ *
+ * Tracks candidates that AI discovery suggested but the user marked as
+ * "not interesting". This allows:
+ * 1. Excluding them from future discoveries
+ * 2. Potential future learning/feedback for AI
+ */
+
+import { sqliteService } from '../sqlite.service.js';
+import { logger } from '../../lib/logger.js';
+
+export const name = '005_discovery_dismissed';
+
+export async function up(): Promise<void> {
+  logger.db('migration-005', 'Creating discovery_dismissed table');
+  sqliteService.getDb().exec(`
+    CREATE TABLE IF NOT EXISTS discovery_dismissed (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      db_id TEXT NOT NULL,
+      person_id TEXT NOT NULL REFERENCES person(person_id) ON DELETE CASCADE,
+      ai_reason TEXT,
+      ai_tags TEXT,
+      dismissed_at TEXT DEFAULT (datetime('now')),
+      UNIQUE(db_id, person_id)
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_discovery_dismissed_db ON discovery_dismissed(db_id);
+    CREATE INDEX IF NOT EXISTS idx_discovery_dismissed_person ON discovery_dismissed(person_id);
+  `);
+  logger.db('migration-005', 'discovery_dismissed table created');
+}
+
+export async function down(): Promise<void> {
+  sqliteService.getDb().exec(`
+    DROP INDEX IF EXISTS idx_discovery_dismissed_person;
+    DROP INDEX IF EXISTS idx_discovery_dismissed_db;
+    DROP TABLE IF EXISTS discovery_dismissed;
+  `);
+}

--- a/server/src/db/migrations/006_place_geocode.ts
+++ b/server/src/db/migrations/006_place_geocode.ts
@@ -1,0 +1,40 @@
+/**
+ * Migration 006: Add place_geocode table
+ *
+ * Caches geocoded coordinates for place text strings.
+ * Used by the migration map visualization to plot ancestors
+ * on a world map with migration lines.
+ */
+
+import { sqliteService } from '../sqlite.service.js';
+import { logger } from '../../lib/logger.js';
+
+export const name = '006_place_geocode';
+
+export async function up(): Promise<void> {
+  logger.db('migration-006', 'Creating place_geocode table');
+  sqliteService.getDb().exec(`
+    CREATE TABLE IF NOT EXISTS place_geocode (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      place_text TEXT NOT NULL UNIQUE,
+      lat REAL,
+      lng REAL,
+      display_name TEXT,
+      geocode_status TEXT NOT NULL DEFAULT 'pending' CHECK(geocode_status IN ('pending', 'resolved', 'not_found', 'error')),
+      geocoded_at TEXT,
+      source TEXT DEFAULT 'nominatim'
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_place_geocode_text ON place_geocode(place_text);
+    CREATE INDEX IF NOT EXISTS idx_place_geocode_status ON place_geocode(geocode_status);
+  `);
+  logger.db('migration-006', 'place_geocode table created');
+}
+
+export async function down(): Promise<void> {
+  sqliteService.getDb().exec(`
+    DROP INDEX IF EXISTS idx_place_geocode_status;
+    DROP INDEX IF EXISTS idx_place_geocode_text;
+    DROP TABLE IF EXISTS place_geocode;
+  `);
+}

--- a/server/src/db/migrations/index.ts
+++ b/server/src/db/migrations/index.ts
@@ -9,6 +9,7 @@ import * as migration002 from './002_expanded_facts.js';
 import * as migration003 from './003_rebuild_fts.js';
 import * as migration004 from './004_external_identity_person_source_index.js';
 import * as migration005 from './005_discovery_dismissed.js';
+import * as migration006 from './006_place_geocode.js';
 
 interface Migration {
   name: string;
@@ -23,6 +24,7 @@ const migrations: Migration[] = [
   migration003,
   migration004,
   migration005,
+  migration006,
 ];
 
 /**

--- a/server/src/db/migrations/index.ts
+++ b/server/src/db/migrations/index.ts
@@ -8,6 +8,7 @@ import * as migration001 from './001_initial.js';
 import * as migration002 from './002_expanded_facts.js';
 import * as migration003 from './003_rebuild_fts.js';
 import * as migration004 from './004_external_identity_person_source_index.js';
+import * as migration005 from './005_discovery_dismissed.js';
 
 interface Migration {
   name: string;
@@ -21,6 +22,7 @@ const migrations: Migration[] = [
   migration002,
   migration003,
   migration004,
+  migration005,
 ];
 
 /**

--- a/server/src/db/schema.sql
+++ b/server/src/db/schema.sql
@@ -243,6 +243,25 @@ CREATE TABLE IF NOT EXISTS provider_mapping (
 CREATE INDEX IF NOT EXISTS idx_provider_mapping_person ON provider_mapping(person_id);
 
 -- ============================================================================
+-- PLACE GEOCODING CACHE
+-- ============================================================================
+
+-- Cached geocoded coordinates for place text strings
+CREATE TABLE IF NOT EXISTS place_geocode (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    place_text TEXT NOT NULL UNIQUE,
+    lat REAL,
+    lng REAL,
+    display_name TEXT,
+    geocode_status TEXT NOT NULL DEFAULT 'pending' CHECK(geocode_status IN ('pending', 'resolved', 'not_found', 'error')),
+    geocoded_at TEXT,
+    source TEXT DEFAULT 'nominatim'
+);
+
+CREATE INDEX IF NOT EXISTS idx_place_geocode_text ON place_geocode(place_text);
+CREATE INDEX IF NOT EXISTS idx_place_geocode_status ON place_geocode(geocode_status);
+
+-- ============================================================================
 -- FULL-TEXT SEARCH
 -- ============================================================================
 

--- a/server/src/db/schema.sql
+++ b/server/src/db/schema.sql
@@ -164,6 +164,20 @@ CREATE INDEX IF NOT EXISTS idx_favorite_db ON favorite(db_id);
 CREATE INDEX IF NOT EXISTS idx_favorite_person ON favorite(person_id);
 CREATE INDEX IF NOT EXISTS idx_favorite_added_at ON favorite(added_at DESC);
 
+-- AI Discovery dismissed candidates (not interesting)
+CREATE TABLE IF NOT EXISTS discovery_dismissed (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    db_id TEXT NOT NULL,
+    person_id TEXT NOT NULL REFERENCES person(person_id) ON DELETE CASCADE,
+    ai_reason TEXT,              -- Why AI thought it was interesting
+    ai_tags TEXT,                -- JSON array of suggested tags
+    dismissed_at TEXT DEFAULT (datetime('now')),
+    UNIQUE(db_id, person_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_discovery_dismissed_db ON discovery_dismissed(db_id);
+CREATE INDEX IF NOT EXISTS idx_discovery_dismissed_person ON discovery_dismissed(person_id);
+
 -- ============================================================================
 -- MEDIA / BLOBS
 -- ============================================================================

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -23,6 +23,7 @@ import { testRunnerRouter } from './routes/test-runner.routes.js';
 import { integrityRouter } from './routes/integrity.routes.js';
 import { ancestryHintsRouter } from './routes/ancestry-hints.routes.js';
 import { ancestryUpdateRouter } from './routes/ancestry-update.routes.js';
+import { mapRouter } from './routes/map.routes.js';
 import { errorHandler } from './middleware/errorHandler.js';
 import { requestLogger } from './middleware/requestLogger.js';
 import { initSocketService } from './services/socket.service.js';
@@ -65,6 +66,7 @@ app.use('/api/test-runner', testRunnerRouter);
 app.use('/api/integrity', integrityRouter);
 app.use('/api/ancestry-hints', ancestryHintsRouter);
 app.use('/api/ancestry-update', ancestryUpdateRouter);
+app.use('/api/map', mapRouter);
 
 // Health check
 app.get('/api/health', (_req, res) => {

--- a/server/src/routes/ai-discovery.routes.ts
+++ b/server/src/routes/ai-discovery.routes.ts
@@ -11,15 +11,16 @@ const router = Router();
  */
 router.post('/:dbId/quick', async (req: Request, res: Response) => {
   const { dbId } = req.params;
-  const { sampleSize, model, excludeBiblical, minBirthYear, customPrompt } = req.body;
+  const { sampleSize, model, excludeBiblical, minBirthYear, maxGenerations, customPrompt } = req.body;
 
-  logger.start('ai-discovery', `Quick discovery request dbId=${dbId} sample=${sampleSize || 100} model=${model || 'default'} excludeBiblical=${excludeBiblical || false} prompt=${customPrompt ? `"${customPrompt.slice(0, 50)}..."` : 'none'}`);
+  logger.start('ai-discovery', `Quick discovery request dbId=${dbId} sample=${sampleSize || 100} model=${model || 'default'} excludeBiblical=${excludeBiblical || false} maxGenerations=${maxGenerations || 'all'} prompt=${customPrompt ? `"${customPrompt.slice(0, 50)}..."` : 'none'}`);
 
   const result = await aiDiscoveryService.quickDiscovery(dbId, {
     sampleSize: sampleSize || 100,
     model,
     excludeBiblical: excludeBiblical || false,
     minBirthYear,
+    maxGenerations,
     customPrompt,
   }).catch(err => {
     logger.error('ai-discovery', `Quick discovery failed: ${err.message}`);
@@ -121,6 +122,120 @@ router.post('/:dbId/apply-batch', async (req: Request, res: Response) => {
   }
 
   res.json({ success: true, data: { applied } });
+});
+
+/**
+ * Dismiss a candidate (mark as not interesting)
+ * POST /api/ai-discovery/:dbId/dismiss
+ */
+router.post('/:dbId/dismiss', async (req: Request, res: Response) => {
+  const { dbId } = req.params;
+  const { personId, whyInteresting, suggestedTags } = req.body;
+
+  if (!personId) {
+    res.status(400).json({ success: false, error: 'personId is required' });
+    return;
+  }
+
+  const result = aiDiscoveryService.dismissCandidate(
+    dbId,
+    personId,
+    whyInteresting,
+    Array.isArray(suggestedTags) ? suggestedTags : []
+  );
+
+  res.json({ success: true, data: result });
+});
+
+/**
+ * Dismiss multiple candidates at once
+ * POST /api/ai-discovery/:dbId/dismiss-batch
+ */
+router.post('/:dbId/dismiss-batch', async (req: Request, res: Response) => {
+  const { dbId } = req.params;
+  const { candidates } = req.body;
+
+  if (!Array.isArray(candidates)) {
+    res.status(400).json({ success: false, error: 'candidates array is required' });
+    return;
+  }
+
+  const result = aiDiscoveryService.dismissCandidatesBatch(dbId, candidates);
+  res.json({ success: true, data: result });
+});
+
+/**
+ * Get dismissed candidates for a database
+ * GET /api/ai-discovery/:dbId/dismissed
+ */
+router.get('/:dbId/dismissed', async (req: Request, res: Response) => {
+  const { dbId } = req.params;
+  const dismissed = aiDiscoveryService.getDismissedCandidates(dbId);
+  const count = aiDiscoveryService.getDismissedCount(dbId);
+  res.json({ success: true, data: { dismissed, count } });
+});
+
+/**
+ * Undo dismiss (restore a candidate)
+ * DELETE /api/ai-discovery/:dbId/dismissed/:personId
+ */
+router.delete('/:dbId/dismissed/:personId', async (req: Request, res: Response) => {
+  const { dbId, personId } = req.params;
+  const result = aiDiscoveryService.undoDismiss(dbId, personId);
+  res.json({ success: true, data: result });
+});
+
+/**
+ * Clear all dismissed candidates for a database
+ * DELETE /api/ai-discovery/:dbId/dismissed
+ */
+router.delete('/:dbId/dismissed', async (req: Request, res: Response) => {
+  const { dbId } = req.params;
+  const result = aiDiscoveryService.clearDismissed(dbId);
+  res.json({ success: true, data: result });
+});
+
+/**
+ * Get recent AI run logs for debugging
+ * GET /api/ai-discovery/debug/runs
+ */
+router.get('/debug/runs', async (_req: Request, res: Response) => {
+  const toolkit = await import('../services/ai-toolkit.service.js').then(m => m.getAIToolkit());
+  const { runner } = toolkit.services;
+
+  const runs = await runner.listRuns(10, 0, 'ai-discovery');
+  res.json({ success: true, data: runs });
+});
+
+/**
+ * Get specific run output for debugging
+ * GET /api/ai-discovery/debug/runs/:runId
+ */
+router.get('/debug/runs/:runId', async (req: Request, res: Response) => {
+  const { runId } = req.params;
+  const toolkit = await import('../services/ai-toolkit.service.js').then(m => m.getAIToolkit());
+  const { runner } = toolkit.services;
+
+  const [metadata, output, prompt] = await Promise.all([
+    runner.getRun(runId),
+    runner.getRunOutput(runId),
+    runner.getRunPrompt(runId),
+  ]);
+
+  if (!metadata) {
+    res.status(404).json({ success: false, error: 'Run not found' });
+    return;
+  }
+
+  res.json({
+    success: true,
+    data: {
+      metadata,
+      output: output?.substring(0, 50000), // Limit output size
+      promptLength: prompt?.length,
+      promptPreview: prompt?.substring(0, 1000),
+    }
+  });
 });
 
 export const aiDiscoveryRouter = router;

--- a/server/src/routes/ai-discovery.routes.ts
+++ b/server/src/routes/ai-discovery.routes.ts
@@ -11,13 +11,12 @@ const router = Router();
  */
 router.post('/:dbId/quick', async (req: Request, res: Response) => {
   const { dbId } = req.params;
-  const { sampleSize, model, excludeBiblical, minBirthYear, maxGenerations, customPrompt } = req.body;
+  const { sampleSize, excludeBiblical, minBirthYear, maxGenerations, customPrompt } = req.body;
 
-  logger.start('ai-discovery', `Quick discovery request dbId=${dbId} sample=${sampleSize || 100} model=${model || 'default'} excludeBiblical=${excludeBiblical || false} maxGenerations=${maxGenerations || 'all'} prompt=${customPrompt ? `"${customPrompt.slice(0, 50)}..."` : 'none'}`);
+  logger.start('ai-discovery', `Quick discovery request dbId=${dbId} sample=${sampleSize || 100} excludeBiblical=${excludeBiblical || false} maxGenerations=${maxGenerations || 'all'} prompt=${customPrompt ? `"${customPrompt.slice(0, 50)}..."` : 'none'}`);
 
   const result = await aiDiscoveryService.quickDiscovery(dbId, {
     sampleSize: sampleSize || 100,
-    model,
     excludeBiblical: excludeBiblical || false,
     minBirthYear,
     maxGenerations,
@@ -40,12 +39,11 @@ router.post('/:dbId/quick', async (req: Request, res: Response) => {
  */
 router.post('/:dbId/start', async (req: Request, res: Response) => {
   const { dbId } = req.params;
-  const { batchSize, maxPersons, model } = req.body;
+  const { batchSize, maxPersons } = req.body;
 
   const result = await aiDiscoveryService.startDiscovery(dbId, {
     batchSize,
     maxPersons,
-    model,
   }).catch(err => {
     res.status(500).json({ success: false, error: err.message });
     return null;
@@ -204,7 +202,7 @@ router.delete('/:dbId/dismissed', async (req: Request, res: Response) => {
 });
 
 /**
- * Debug endpoints - gated behind ENABLE_AI_DEBUG env var or non-production mode.
+ * Debug endpoints - gated behind ENABLE_AI_DEBUG=1 env var.
  * These expose AI run metadata, prompts, and outputs.
  */
 const debugEnabled = process.env.ENABLE_AI_DEBUG === '1';

--- a/server/src/routes/ai-discovery.routes.ts
+++ b/server/src/routes/ai-discovery.routes.ts
@@ -107,6 +107,10 @@ router.post('/:dbId/apply-batch', async (req: Request, res: Response) => {
     res.status(400).json({ success: false, error: 'candidates array is required' });
     return;
   }
+  if (candidates.length > 1000) {
+    res.status(400).json({ success: false, error: 'Maximum 1000 candidates per batch' });
+    return;
+  }
 
   let applied = 0;
   for (const candidate of candidates) {
@@ -157,6 +161,10 @@ router.post('/:dbId/dismiss-batch', async (req: Request, res: Response) => {
 
   if (!Array.isArray(candidates)) {
     res.status(400).json({ success: false, error: 'candidates array is required' });
+    return;
+  }
+  if (candidates.length > 1000) {
+    res.status(400).json({ success: false, error: 'Maximum 1000 candidates per batch' });
     return;
   }
 

--- a/server/src/routes/ai-discovery.routes.ts
+++ b/server/src/routes/ai-discovery.routes.ts
@@ -207,7 +207,7 @@ router.delete('/:dbId/dismissed', async (req: Request, res: Response) => {
  * Debug endpoints - gated behind ENABLE_AI_DEBUG env var or non-production mode.
  * These expose AI run metadata, prompts, and outputs.
  */
-const debugEnabled = process.env.ENABLE_AI_DEBUG === '1' || process.env.NODE_ENV !== 'production';
+const debugEnabled = process.env.ENABLE_AI_DEBUG === '1';
 
 /**
  * Get recent AI run logs for debugging

--- a/server/src/routes/ai-discovery.routes.ts
+++ b/server/src/routes/ai-discovery.routes.ts
@@ -196,10 +196,20 @@ router.delete('/:dbId/dismissed', async (req: Request, res: Response) => {
 });
 
 /**
+ * Debug endpoints - gated behind ENABLE_AI_DEBUG env var or non-production mode.
+ * These expose AI run metadata, prompts, and outputs.
+ */
+const debugEnabled = process.env.ENABLE_AI_DEBUG === '1' || process.env.NODE_ENV !== 'production';
+
+/**
  * Get recent AI run logs for debugging
  * GET /api/ai-discovery/debug/runs
  */
 router.get('/debug/runs', async (_req: Request, res: Response) => {
+  if (!debugEnabled) {
+    res.status(403).json({ success: false, error: 'Debug endpoints disabled. Set ENABLE_AI_DEBUG=1 to enable.' });
+    return;
+  }
   const toolkit = await import('../services/ai-toolkit.service.js').then(m => m.getAIToolkit());
   const { runner } = toolkit.services;
 
@@ -212,6 +222,10 @@ router.get('/debug/runs', async (_req: Request, res: Response) => {
  * GET /api/ai-discovery/debug/runs/:runId
  */
 router.get('/debug/runs/:runId', async (req: Request, res: Response) => {
+  if (!debugEnabled) {
+    res.status(403).json({ success: false, error: 'Debug endpoints disabled. Set ENABLE_AI_DEBUG=1 to enable.' });
+    return;
+  }
   const { runId } = req.params;
   const toolkit = await import('../services/ai-toolkit.service.js').then(m => m.getAIToolkit());
   const { runner } = toolkit.services;

--- a/server/src/routes/map.routes.ts
+++ b/server/src/routes/map.routes.ts
@@ -41,7 +41,7 @@ mapRouter.post('/geocode/reset-not-found', (_req: Request, res: Response) => {
  * Use POST /geocode/reset-not-found first to retry previously failed places.
  */
 mapRouter.get('/geocode/stream', async (req: Request, res: Response) => {
-  const dbId = req.query.dbId as string;
+  const dbId = typeof req.query.dbId === 'string' ? req.query.dbId : '';
 
   if (!dbId) {
     res.status(400).json({ success: false, error: 'dbId query param required' });

--- a/server/src/routes/map.routes.ts
+++ b/server/src/routes/map.routes.ts
@@ -1,0 +1,114 @@
+/**
+ * Map routes - Migration map visualization endpoints
+ *
+ * Provides map data (person coordinates) and batch geocoding via SSE.
+ *
+ * IMPORTANT: Static routes (geocode/*) must come before parameterized routes (/:dbId/*)
+ * to prevent Express from matching "geocode" as a :dbId parameter.
+ */
+
+import { Router, Request, Response } from 'express';
+import { mapService } from '../services/map.service.js';
+import { geocodeService } from '../services/geocode.service.js';
+import { logger } from '../lib/logger.js';
+
+export const mapRouter = Router();
+
+/**
+ * GET /api/map/geocode/stats
+ * Get geocode cache statistics
+ */
+mapRouter.get('/geocode/stats', (_req: Request, res: Response) => {
+  const stats = geocodeService.getGeocodeStats();
+  res.json({ success: true, data: stats });
+});
+
+/**
+ * POST /api/map/geocode/reset-not-found
+ * Reset all not_found entries to pending so they get retried with broadening
+ */
+mapRouter.post('/geocode/reset-not-found', (_req: Request, res: Response) => {
+  const count = geocodeService.resetNotFound();
+  logger.api('map', `🔄 Reset ${count} not_found geocode entries to pending`);
+  res.json({ success: true, data: { reset: count } });
+});
+
+/**
+ * GET /api/map/geocode/stream
+ * SSE stream for batch geocoding places in a database.
+ * Uses EventSource-compatible GET endpoint (POST SSE is unreliable with fetch).
+ * Auto-resets not_found entries so broadening can retry them.
+ */
+mapRouter.get('/geocode/stream', async (req: Request, res: Response) => {
+  const dbId = req.query.dbId as string;
+
+  if (!dbId) {
+    res.status(400).json({ success: false, error: 'dbId query param required' });
+    return;
+  }
+
+  // Reset not_found entries so broadening logic can retry them
+  const resetCount = geocodeService.resetNotFound();
+  if (resetCount > 0) {
+    logger.api('map', `🔄 Reset ${resetCount} not_found entries for re-geocoding with broadening`);
+  }
+
+  const placesToGeocode = mapService.getUngeocodedPlaces(dbId);
+
+  // SSE headers
+  res.setHeader('Content-Type', 'text/event-stream');
+  res.setHeader('Cache-Control', 'no-cache');
+  res.setHeader('Connection', 'keep-alive');
+  res.setHeader('X-Accel-Buffering', 'no'); // Disable nginx buffering
+  res.setTimeout(0); // No timeout for SSE
+  res.flushHeaders();
+
+  if (placesToGeocode.length === 0) {
+    res.write(`data: ${JSON.stringify({ type: 'complete', current: 0, total: 0 })}\n\n`);
+    res.end();
+    return;
+  }
+
+  logger.api('map', `🗺️ Starting batch geocode of ${placesToGeocode.length} places`);
+
+  let cancelled = false;
+  req.on('close', () => { cancelled = true; });
+
+  for await (const progress of geocodeService.batchGeocode(placesToGeocode)) {
+    if (cancelled) break;
+    res.write(`data: ${JSON.stringify(progress)}\n\n`);
+  }
+
+  if (!cancelled) {
+    res.write(`data: ${JSON.stringify({ type: 'complete', current: placesToGeocode.length, total: placesToGeocode.length })}\n\n`);
+  }
+
+  res.end();
+});
+
+/**
+ * GET /api/map/:dbId/sparse
+ * Get sparse tree map data (favorites only)
+ */
+mapRouter.get('/:dbId/sparse', async (req: Request, res: Response) => {
+  const { dbId } = req.params;
+
+  logger.api('map', `Sparse tree map data for ${dbId}`);
+
+  const data = await mapService.getSparseTreeMapData(dbId);
+  res.json({ success: true, data });
+});
+
+/**
+ * GET /api/map/:dbId/:personId
+ * Get ancestry tree map data for a person
+ */
+mapRouter.get('/:dbId/:personId', async (req: Request, res: Response) => {
+  const { dbId, personId } = req.params;
+  const depth = parseInt(req.query.depth as string) || 8;
+
+  logger.api('map', `Ancestry map data for ${personId} in ${dbId}, depth=${depth}`);
+
+  const data = await mapService.getAncestryMapData(dbId, personId, depth);
+  res.json({ success: true, data });
+});

--- a/server/src/services/ai-discovery.service.ts
+++ b/server/src/services/ai-discovery.service.ts
@@ -550,10 +550,12 @@ export const aiDiscoveryService = {
     candidates: Array<{ personId: string; whyInteresting?: string; suggestedTags?: string[] }>
   ): { dismissed: number } {
     let dismissed = 0;
-    for (const candidate of candidates) {
-      this.dismissCandidate(dbId, candidate.personId, candidate.whyInteresting, candidate.suggestedTags);
-      dismissed++;
-    }
+    sqliteService.transaction(() => {
+      for (const candidate of candidates) {
+        this.dismissCandidate(dbId, candidate.personId, candidate.whyInteresting, candidate.suggestedTags);
+        dismissed++;
+      }
+    });
     return { dismissed };
   },
 

--- a/server/src/services/ai-discovery.service.ts
+++ b/server/src/services/ai-discovery.service.ts
@@ -1,61 +1,64 @@
-import { spawn } from 'child_process';
 import { databaseService } from './database.service.js';
 import { favoritesService, PRESET_TAGS } from './favorites.service.js';
 import { idMappingService } from './id-mapping.service.js';
 import { sqliteService } from '../db/sqlite.service.js';
+import { getAIToolkit } from './ai-toolkit.service.js';
 import { logger } from '../lib/logger.js';
 import type { Person } from '@fsf/shared';
 
 /**
- * Execute Claude CLI with prompt piped to stdin
+ * Execute AI prompt using the configured AI toolkit provider
  */
-async function executeClaudeCli(prompt: string, timeoutMs = 300000): Promise<string> {
+async function executeAiPrompt(prompt: string, timeoutMs = 300000): Promise<string> {
   const startTime = Date.now();
-  logger.start('ai-discovery', `Invoking Claude CLI, prompt: ${prompt.length} chars, timeout: ${timeoutMs}ms`);
+  const toolkit = getAIToolkit();
+  const { providers, runner } = toolkit.services;
+
+  const activeProvider = await providers.getActiveProvider();
+  if (!activeProvider) {
+    throw new Error('No active AI provider configured. Please configure one in Settings > AI.');
+  }
+
+  if (!activeProvider.enabled) {
+    throw new Error(`AI provider "${activeProvider.name}" is disabled.`);
+  }
+
+  logger.start('ai-discovery', `Invoking ${activeProvider.name} (${activeProvider.type}), prompt: ${prompt.length} chars`);
+
+  const { runId, provider, timeout } = await runner.createRun({
+    providerId: activeProvider.id,
+    prompt,
+    timeout: timeoutMs,
+    source: 'ai-discovery'
+  });
 
   return new Promise((resolve, reject) => {
-    const child = spawn('claude', ['--print'], {
-      stdio: ['pipe', 'pipe', 'pipe'],
-    });
+    let output = '';
 
-    let stdout = '';
-    let stderr = '';
+    const onData = (text: string) => {
+      output += text;
+    };
 
-    const timeout = setTimeout(() => {
-      logger.error('ai-discovery', `Claude CLI timed out after ${timeoutMs}ms`);
-      child.kill('SIGTERM');
-      reject(new Error('Claude CLI timed out'));
-    }, timeoutMs);
-
-    child.stdout.on('data', (data) => {
-      stdout += data.toString();
-    });
-
-    child.stderr.on('data', (data) => {
-      stderr += data.toString();
-    });
-
-    child.on('close', (code) => {
-      clearTimeout(timeout);
+    const onComplete = (metadata: { success: boolean; error?: string; errorDetails?: string; duration?: number }) => {
       const elapsed = Date.now() - startTime;
-      if (code === 0) {
-        logger.done('ai-discovery', `Claude CLI completed in ${elapsed}ms, response: ${stdout.length} chars`);
-        resolve(stdout);
+      if (metadata.success) {
+        logger.done('ai-discovery', `${activeProvider.name} completed in ${elapsed}ms, response: ${output.length} chars`);
+        resolve(output);
       } else {
-        logger.error('ai-discovery', `Claude CLI failed code=${code} after ${elapsed}ms: ${stderr || 'Unknown error'}`);
-        reject(new Error(`Claude CLI failed: ${stderr || 'Unknown error'}`));
+        const errorMsg = metadata.errorDetails || metadata.error || 'Unknown error';
+        logger.error('ai-discovery', `${activeProvider.name} failed after ${elapsed}ms: ${metadata.error || 'Unknown error'}`);
+        if (metadata.errorDetails) {
+          logger.error('ai-discovery', `Error details: ${metadata.errorDetails}`);
+        }
+        reject(new Error(`AI run failed: ${errorMsg}`));
       }
-    });
+    };
 
-    child.on('error', (err) => {
-      clearTimeout(timeout);
-      logger.error('ai-discovery', `Claude CLI spawn error: ${err.message}`);
-      reject(err);
-    });
-
-    // Write prompt to stdin and close
-    child.stdin.write(prompt);
-    child.stdin.end();
+    if (provider.type === 'cli') {
+      runner.executeCliRun(runId, provider, prompt, process.cwd(), onData, onComplete, timeout || timeoutMs);
+    } else {
+      runner.executeApiRun(runId, provider, provider.defaultModel, prompt, process.cwd(), null, onData, onComplete);
+    }
   });
 }
 
@@ -128,11 +131,42 @@ function parseAiResponse(response: string): Array<{
   suggestedTags: string[];
   confidence: 'high' | 'medium' | 'low';
 }> {
-  // Try to extract JSON from the response
-  const jsonMatch = response.match(/\[[\s\S]*\]/);
-  if (!jsonMatch) return [];
+  // Look for the last JSON array containing real personIds (starting with 01KF)
+  // This avoids matching example JSON from the prompt
+  const realJsonStart = response.lastIndexOf('[{"personId":"01KF');
+  if (realJsonStart === -1) {
+    // Try alternate format with whitespace
+    const altStart = response.lastIndexOf('[\n  {"personId":"01KF');
+    if (altStart === -1) return [];
+    return parseJsonFromPosition(response, altStart);
+  }
+  return parseJsonFromPosition(response, realJsonStart);
+}
 
-  const parsed = JSON.parse(jsonMatch[0]);
+function parseJsonFromPosition(response: string, startPos: number): Array<{
+  personId: string;
+  whyInteresting: string;
+  suggestedTags: string[];
+  confidence: 'high' | 'medium' | 'low';
+}> {
+  // Find the matching closing bracket by counting
+  let depth = 0;
+  let endPos = startPos;
+  for (let i = startPos; i < response.length; i++) {
+    if (response[i] === '[') depth++;
+    else if (response[i] === ']') {
+      depth--;
+      if (depth === 0) {
+        endPos = i + 1;
+        break;
+      }
+    }
+  }
+
+  if (endPos <= startPos) return [];
+
+  const jsonStr = response.substring(startPos, endPos);
+  const parsed = JSON.parse(jsonStr);
   if (!Array.isArray(parsed)) return [];
 
   return parsed.filter(item =>
@@ -234,7 +268,7 @@ export const aiDiscoveryService = {
       const prompt = buildDiscoveryPrompt(batchSummaries, existingFavoriteIds);
 
       // Execute Claude CLI directly with piped input
-      const output = await executeClaudeCli(prompt, 300000);
+      const output = await executeAiPrompt(prompt, 300000);
 
       // Parse AI response
       const aiCandidates = parseAiResponse(output);
@@ -321,19 +355,24 @@ export const aiDiscoveryService = {
       model?: string;
       excludeBiblical?: boolean;
       minBirthYear?: number;
+      maxGenerations?: number;
       customPrompt?: string;
     }
   ): Promise<DiscoveryResult> {
     const sampleSize = options?.sampleSize ?? 100;
     const excludeBiblical = options?.excludeBiblical ?? false;
     const minBirthYear = options?.minBirthYear ?? (excludeBiblical ? 500 : undefined);
+    const maxGenerations = options?.maxGenerations;
     const customPrompt = options?.customPrompt;
-    logger.start('ai-discovery', `Quick discovery dbId=${dbId} sample=${sampleSize} excludeBiblical=${excludeBiblical} minBirthYear=${minBirthYear || 'none'} prompt=${customPrompt ? `"${customPrompt.slice(0, 50)}..."` : 'none'}`);
+    logger.start('ai-discovery', `Quick discovery dbId=${dbId} sample=${sampleSize} excludeBiblical=${excludeBiblical} minBirthYear=${minBirthYear || 'none'} maxGenerations=${maxGenerations || 'none'} prompt=${customPrompt ? `"${customPrompt.slice(0, 50)}..."` : 'none'}`);
 
-    // Get existing favorites to exclude
+    // Get existing favorites and dismissed to exclude
     const existingFavorites = await favoritesService.getFavoritesInDatabase(dbId);
     const existingFavoriteIds = new Set(existingFavorites.map(f => f.personId));
-    logger.data('ai-discovery', `Excluding ${existingFavoriteIds.size} existing favorites`);
+    const dismissedCandidates = this.getDismissedCandidates(dbId);
+    const dismissedIds = new Set(dismissedCandidates.map(d => d.personId));
+    const excludeIds = new Set([...existingFavoriteIds, ...dismissedIds]);
+    logger.data('ai-discovery', `Excluding ${existingFavoriteIds.size} existing favorites and ${dismissedIds.size} dismissed`);
 
     // Get persons with interesting attributes first (prioritize those with bios, occupations)
     let personsToAnalyze: Array<{ id: string; person: Person }> = [];
@@ -362,6 +401,10 @@ export const aiDiscoveryService = {
            )`
         : '';
 
+      const generationFilter = maxGenerations !== undefined
+        ? `AND dm.generation IS NOT NULL AND dm.generation <= @maxGenerations`
+        : '';
+
       const rows = sqliteService.queryAll<{
         person_id: string;
         display_name: string;
@@ -373,16 +416,17 @@ export const aiDiscoveryService = {
          LEFT JOIN claim c ON p.person_id = c.person_id AND c.predicate = 'occupation'
          WHERE dm.db_id = @dbId
          ${birthYearFilter}
+         ${generationFilter}
          ORDER BY
            CASE WHEN p.bio IS NOT NULL AND p.bio != '' THEN 0 ELSE 1 END,
            CASE WHEN c.value_text IS NOT NULL THEN 0 ELSE 1 END
          LIMIT @limit`,
-        { dbId, limit: sampleSize * 2, minBirthYear } // Get extra to filter out favorites
+        { dbId, limit: sampleSize * 2, minBirthYear, maxGenerations } // Get extra to filter out favorites
       );
 
       const db = await databaseService.getDatabase(dbId);
       personsToAnalyze = rows
-        .filter(r => !existingFavoriteIds.has(r.person_id))
+        .filter(r => !excludeIds.has(r.person_id))
         .slice(0, sampleSize)
         .map(r => ({ id: r.person_id, person: db[r.person_id] }))
         .filter(p => p.person);
@@ -391,7 +435,7 @@ export const aiDiscoveryService = {
       const db = await databaseService.getDatabase(dbId);
       personsToAnalyze = Object.entries(db)
         .filter(([id, person]) => {
-          if (existingFavoriteIds.has(id)) return false;
+          if (excludeIds.has(id)) return false;
           if (minBirthYear !== undefined) {
             const birthYear = getBirthYear(person);
             if (birthYear !== null && birthYear < minBirthYear) return false;
@@ -422,7 +466,7 @@ export const aiDiscoveryService = {
 
     // Execute Claude CLI directly with piped input
     logger.api('ai-discovery', `Sending prompt to Claude CLI...`);
-    const output = await executeClaudeCli(prompt, 300000);
+    const output = await executeAiPrompt(prompt, 300000);
 
     // Parse response
     logger.data('ai-discovery', `Parsing AI response...`);
@@ -458,5 +502,109 @@ export const aiDiscoveryService = {
       totalAnalyzed: personsToAnalyze.length,
       runId: `discovery-${Date.now()}`,
     };
+  },
+
+  /**
+   * Dismiss a candidate (mark as not interesting)
+   */
+  dismissCandidate(
+    dbId: string,
+    personId: string,
+    aiReason?: string,
+    aiTags?: string[]
+  ): { success: boolean } {
+    sqliteService.run(
+      `INSERT OR REPLACE INTO discovery_dismissed (db_id, person_id, ai_reason, ai_tags, dismissed_at)
+       VALUES (@dbId, @personId, @aiReason, @aiTags, datetime('now'))`,
+      {
+        dbId,
+        personId,
+        aiReason: aiReason || null,
+        aiTags: aiTags ? JSON.stringify(aiTags) : null,
+      }
+    );
+    logger.done('ai-discovery', `Dismissed candidate personId=${personId}`);
+    return { success: true };
+  },
+
+  /**
+   * Dismiss multiple candidates at once
+   */
+  dismissCandidatesBatch(
+    dbId: string,
+    candidates: Array<{ personId: string; whyInteresting?: string; suggestedTags?: string[] }>
+  ): { dismissed: number } {
+    let dismissed = 0;
+    for (const candidate of candidates) {
+      this.dismissCandidate(dbId, candidate.personId, candidate.whyInteresting, candidate.suggestedTags);
+      dismissed++;
+    }
+    return { dismissed };
+  },
+
+  /**
+   * Get dismissed candidates for a database
+   */
+  getDismissedCandidates(dbId: string): Array<{
+    personId: string;
+    aiReason: string | null;
+    aiTags: string[];
+    dismissedAt: string;
+  }> {
+    const rows = sqliteService.queryAll<{
+      person_id: string;
+      ai_reason: string | null;
+      ai_tags: string | null;
+      dismissed_at: string;
+    }>(
+      `SELECT person_id, ai_reason, ai_tags, dismissed_at
+       FROM discovery_dismissed
+       WHERE db_id = @dbId
+       ORDER BY dismissed_at DESC`,
+      { dbId }
+    );
+
+    return rows.map(row => ({
+      personId: row.person_id,
+      aiReason: row.ai_reason,
+      aiTags: row.ai_tags ? JSON.parse(row.ai_tags) : [],
+      dismissedAt: row.dismissed_at,
+    }));
+  },
+
+  /**
+   * Get count of dismissed candidates
+   */
+  getDismissedCount(dbId: string): number {
+    const result = sqliteService.queryOne<{ count: number }>(
+      `SELECT COUNT(*) as count FROM discovery_dismissed WHERE db_id = @dbId`,
+      { dbId }
+    );
+    return result?.count || 0;
+  },
+
+  /**
+   * Undo dismiss (restore a candidate)
+   */
+  undoDismiss(dbId: string, personId: string): { success: boolean } {
+    sqliteService.run(
+      `DELETE FROM discovery_dismissed WHERE db_id = @dbId AND person_id = @personId`,
+      { dbId, personId }
+    );
+    logger.done('ai-discovery', `Undid dismiss for personId=${personId}`);
+    return { success: true };
+  },
+
+  /**
+   * Clear all dismissed candidates for a database
+   */
+  clearDismissed(dbId: string): { cleared: number } {
+    const count = this.getDismissedCount(dbId);
+    sqliteService.run(
+      `DELETE FROM discovery_dismissed WHERE db_id = @dbId`,
+      { dbId }
+    );
+    logger.done('ai-discovery', `Cleared ${count} dismissed candidates for dbId=${dbId}`);
+    return { cleared: count };
   },
 };

--- a/server/src/services/ai-discovery.service.ts
+++ b/server/src/services/ai-discovery.service.ts
@@ -201,7 +201,6 @@ export const aiDiscoveryService = {
     options?: {
       batchSize?: number;
       maxPersons?: number;
-      model?: string;
     }
   ): Promise<{ runId: string; message: string }> {
     const runId = `discovery-${dbId}-${Date.now()}`;
@@ -219,7 +218,7 @@ export const aiDiscoveryService = {
     });
 
     // Run discovery asynchronously
-    this.runDiscovery(runId, dbId, batchSize, maxPersons, options?.model).catch(err => {
+    this.runDiscovery(runId, dbId, batchSize, maxPersons).catch(err => {
       const progress = discoveryRuns.get(runId);
       if (progress) {
         progress.status = 'failed';
@@ -244,8 +243,7 @@ export const aiDiscoveryService = {
     runId: string,
     dbId: string,
     batchSize: number,
-    maxPersons: number,
-    _model?: string
+    maxPersons: number
   ): Promise<DiscoveryResult> {
     const progress = discoveryRuns.get(runId);
     if (!progress) throw new Error('Run not found');
@@ -367,7 +365,6 @@ export const aiDiscoveryService = {
     dbId: string,
     options?: {
       sampleSize?: number;
-      model?: string;
       excludeBiblical?: boolean;
       minBirthYear?: number;
       maxGenerations?: number;

--- a/server/src/services/geocode.service.ts
+++ b/server/src/services/geocode.service.ts
@@ -135,8 +135,10 @@ async function queryNominatim(placeText: string): Promise<QueryResult> {
   const parts = placeText.split(',').map(s => s.trim()).filter(Boolean);
   let hadError = false;
 
-  // Try full query first, then progressively broader
-  for (let skip = 0; skip <= parts.length - 2; skip++) {
+  // Try full query first, then progressively strip leftmost segments.
+  // For single-segment places, parts.length - 1 = 0, so we try the full query once.
+  const maxSkip = Math.max(0, parts.length - 2);
+  for (let skip = 0; skip <= maxSkip; skip++) {
     const query = parts.slice(skip).join(', ');
     const result = await fetchNominatim(query);
 
@@ -154,11 +156,12 @@ async function queryNominatim(placeText: string): Promise<QueryResult> {
 }
 
 export interface GeocodeProgress {
-  type: 'progress' | 'complete';
+  type: 'progress' | 'complete' | 'error';
   current: number;
   total: number;
   place?: string;
   status?: 'resolved' | 'not_found' | 'error' | 'cached';
+  message?: string;
 }
 
 /**

--- a/server/src/services/geocode.service.ts
+++ b/server/src/services/geocode.service.ts
@@ -1,0 +1,237 @@
+/**
+ * Geocoding service - resolves place text to coordinates using Nominatim
+ *
+ * Caches results in the place_geocode SQLite table so places are only
+ * geocoded once. Not-found places are permanently marked to avoid
+ * re-querying Nominatim.
+ */
+
+import { sqliteService } from '../db/sqlite.service.js';
+import { logger } from '../lib/logger.js';
+
+const NOMINATIM_URL = 'https://nominatim.openstreetmap.org/search';
+const USER_AGENT = 'SparseTree/0.7.0 (genealogy toolkit)';
+const REQUEST_DELAY_MS = 1100; // Nominatim requires 1 req/sec max
+const RATE_LIMIT_PAUSE_MS = 60_000;
+
+interface GeocodeRow {
+  place_text: string;
+  lat: number | null;
+  lng: number | null;
+  display_name: string | null;
+  geocode_status: string;
+}
+
+interface NominatimResult {
+  lat: string;
+  lon: string;
+  display_name: string;
+}
+
+function normalizePlaceText(text: string): string {
+  return text.toLowerCase().trim();
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+/**
+ * Look up a place in the cache, optionally geocoding if not found
+ */
+function lookupPlace(placeText: string): GeocodeRow | undefined {
+  const normalized = normalizePlaceText(placeText);
+  return sqliteService.queryOne<GeocodeRow>(
+    'SELECT place_text, lat, lng, display_name, geocode_status FROM place_geocode WHERE place_text = @text',
+    { text: normalized }
+  );
+}
+
+/**
+ * Insert or update a place geocode record
+ */
+function upsertPlace(
+  placeText: string,
+  lat: number | null,
+  lng: number | null,
+  displayName: string | null,
+  status: 'resolved' | 'not_found' | 'error'
+): void {
+  const normalized = normalizePlaceText(placeText);
+  sqliteService.run(
+    `INSERT INTO place_geocode (place_text, lat, lng, display_name, geocode_status, geocoded_at)
+     VALUES (@text, @lat, @lng, @displayName, @status, datetime('now'))
+     ON CONFLICT(place_text) DO UPDATE SET
+       lat = @lat, lng = @lng, display_name = @displayName,
+       geocode_status = @status, geocoded_at = datetime('now')`,
+    { text: normalized, lat, lng, displayName, status }
+  );
+}
+
+/**
+ * Ensure a place_text is inserted as pending (for tracking before geocoding)
+ */
+function ensurePending(placeText: string): void {
+  const normalized = normalizePlaceText(placeText);
+  sqliteService.run(
+    `INSERT OR IGNORE INTO place_geocode (place_text, geocode_status) VALUES (@text, 'pending')`,
+    { text: normalized }
+  );
+}
+
+/**
+ * Single Nominatim request with rate-limit handling
+ */
+async function fetchNominatim(query: string): Promise<NominatimResult | null> {
+  const url = `${NOMINATIM_URL}?${new URLSearchParams({ q: query, format: 'json', limit: '1' })}`;
+
+  const response = await fetch(url, { headers: { 'User-Agent': USER_AGENT } });
+
+  if (response.status === 429) {
+    logger.warn('geocode', `⏳ Rate limited by Nominatim, pausing ${RATE_LIMIT_PAUSE_MS / 1000}s`);
+    await delay(RATE_LIMIT_PAUSE_MS);
+    const retry = await fetch(url, { headers: { 'User-Agent': USER_AGENT } });
+    if (!retry.ok) return null;
+    const retryData: NominatimResult[] = await retry.json();
+    return retryData[0] || null;
+  }
+
+  if (!response.ok) return null;
+
+  const data: NominatimResult[] = await response.json();
+  return data[0] || null;
+}
+
+/**
+ * Query Nominatim with progressive broadening.
+ * For comma-separated places like "Cornouaile, Visseiche, Ille-et-Vilaine, Brittany, France",
+ * if the full query returns no results, progressively strip the leftmost (most specific)
+ * segment and retry with broader locations. Stops at 2 remaining segments minimum.
+ */
+async function queryNominatim(placeText: string): Promise<{ lat: number; lng: number; displayName: string } | null> {
+  const parts = placeText.split(',').map(s => s.trim()).filter(Boolean);
+
+  // Try full query first, then progressively broader
+  for (let skip = 0; skip <= parts.length - 2; skip++) {
+    const query = parts.slice(skip).join(', ');
+    const result = await fetchNominatim(query);
+
+    if (result) {
+      if (skip > 0) {
+        logger.ok('geocode', `🔍 Broadened "${placeText}" → "${query}"`);
+      }
+      return { lat: parseFloat(result.lat), lng: parseFloat(result.lon), displayName: result.display_name };
+    }
+
+    // Rate limit delay before next broadening attempt
+    if (skip < parts.length - 2) {
+      await delay(REQUEST_DELAY_MS);
+    }
+  }
+
+  return null;
+}
+
+export interface GeocodeProgress {
+  type: 'progress' | 'complete';
+  current: number;
+  total: number;
+  place?: string;
+  status?: 'resolved' | 'not_found' | 'error' | 'cached';
+}
+
+/**
+ * Batch geocode a list of places, yielding progress events.
+ * Skips places already resolved or marked not_found.
+ */
+async function* batchGeocode(places: string[]): AsyncGenerator<GeocodeProgress> {
+  const total = places.length;
+
+  for (let i = 0; i < places.length; i++) {
+    const place = places[i];
+    const normalized = normalizePlaceText(place);
+
+    // Check cache first
+    const cached = lookupPlace(normalized);
+    if (cached && (cached.geocode_status === 'resolved' || cached.geocode_status === 'not_found')) {
+      yield { type: 'progress', current: i + 1, total, place, status: 'cached' };
+      continue;
+    }
+
+    // Ensure pending record exists
+    ensurePending(normalized);
+
+    // Query Nominatim
+    const result = await queryNominatim(normalized);
+
+    if (result) {
+      upsertPlace(normalized, result.lat, result.lng, result.displayName, 'resolved');
+      logger.ok('geocode', `📍 Resolved: "${place}" → ${result.lat.toFixed(4)}, ${result.lng.toFixed(4)}`);
+      yield { type: 'progress', current: i + 1, total, place, status: 'resolved' };
+    } else {
+      upsertPlace(normalized, null, null, null, 'not_found');
+      logger.warn('geocode', `❓ Not found: "${place}"`);
+      yield { type: 'progress', current: i + 1, total, place, status: 'not_found' };
+    }
+
+    // Rate limit delay (skip on last item)
+    if (i < places.length - 1) {
+      await delay(REQUEST_DELAY_MS);
+    }
+  }
+
+  yield { type: 'complete', current: total, total };
+}
+
+/**
+ * Get geocoding statistics
+ */
+function getGeocodeStats(): { resolved: number; pending: number; notFound: number; error: number; total: number } {
+  const rows = sqliteService.queryAll<{ geocode_status: string; count: number }>(
+    'SELECT geocode_status, COUNT(*) as count FROM place_geocode GROUP BY geocode_status'
+  );
+  const stats = { resolved: 0, pending: 0, notFound: 0, error: 0, total: 0 };
+  for (const row of rows) {
+    if (row.geocode_status === 'resolved') stats.resolved = row.count;
+    else if (row.geocode_status === 'pending') stats.pending = row.count;
+    else if (row.geocode_status === 'not_found') stats.notFound = row.count;
+    else if (row.geocode_status === 'error') stats.error = row.count;
+    stats.total += row.count;
+  }
+  return stats;
+}
+
+/**
+ * Get all resolved geocode entries as a lookup map
+ */
+function getResolvedCoords(): Map<string, { lat: number; lng: number; displayName: string }> {
+  const rows = sqliteService.queryAll<GeocodeRow>(
+    "SELECT place_text, lat, lng, display_name FROM place_geocode WHERE geocode_status = 'resolved'"
+  );
+  const map = new Map<string, { lat: number; lng: number; displayName: string }>();
+  for (const row of rows) {
+    if (row.lat !== null && row.lng !== null) {
+      map.set(row.place_text, { lat: row.lat, lng: row.lng, displayName: row.display_name || row.place_text });
+    }
+  }
+  return map;
+}
+
+/**
+ * Reset all not_found entries to pending so they get retried with broadening
+ */
+function resetNotFound(): number {
+  const result = sqliteService.run(
+    "UPDATE place_geocode SET geocode_status = 'pending', geocoded_at = NULL WHERE geocode_status = 'not_found'"
+  );
+  return result.changes;
+}
+
+export const geocodeService = {
+  lookupPlace,
+  batchGeocode,
+  getGeocodeStats,
+  getResolvedCoords,
+  normalizePlaceText,
+  resetNotFound,
+};

--- a/server/src/services/geocode.service.ts
+++ b/server/src/services/geocode.service.ts
@@ -246,11 +246,22 @@ function resetNotFound(): number {
   return result.changes;
 }
 
+/**
+ * Get all not_found place texts as a Set (normalized) for filtering ungeocoded lists
+ */
+function getNotFoundPlaces(): Set<string> {
+  const rows = sqliteService.queryAll<{ place_text: string }>(
+    "SELECT place_text FROM place_geocode WHERE geocode_status = 'not_found'"
+  );
+  return new Set(rows.map(r => r.place_text));
+}
+
 export const geocodeService = {
   lookupPlace,
   batchGeocode,
   getGeocodeStats,
   getResolvedCoords,
+  getNotFoundPlaces,
   normalizePlaceText,
   resetNotFound,
 };

--- a/server/src/services/map.service.ts
+++ b/server/src/services/map.service.ts
@@ -46,12 +46,13 @@ function getPersonsWithPlaces(personIds: string[]): Map<string, {
       death_year: number | null;
     }>(
       `SELECT p.person_id, p.display_name, p.gender,
-        (SELECT place FROM vital_event WHERE person_id = p.person_id AND event_type = 'birth' LIMIT 1) as birth_place,
-        (SELECT date_year FROM vital_event WHERE person_id = p.person_id AND event_type = 'birth' LIMIT 1) as birth_year,
-        (SELECT place FROM vital_event WHERE person_id = p.person_id AND event_type = 'death' LIMIT 1) as death_place,
-        (SELECT date_year FROM vital_event WHERE person_id = p.person_id AND event_type = 'death' LIMIT 1) as death_year
+        vb.place AS birth_place, vb.date_year AS birth_year,
+        vd.place AS death_place, vd.date_year AS death_year
        FROM person p
-       WHERE p.person_id IN (${placeholders})`,
+       LEFT JOIN vital_event vb ON vb.person_id = p.person_id AND vb.event_type = 'birth'
+       LEFT JOIN vital_event vd ON vd.person_id = p.person_id AND vd.event_type = 'death'
+       WHERE p.person_id IN (${placeholders})
+       GROUP BY p.person_id`,
       params
     );
 

--- a/server/src/services/map.service.ts
+++ b/server/src/services/map.service.ts
@@ -202,13 +202,16 @@ export const mapService = {
     const notFoundPlaces = geocodeService.getNotFoundPlaces();
 
     // Build map persons
-    const { persons, ungeocoded } = buildMapPersons(entries, personsData, coordsMap, notFoundPlaces);
+    const { persons } = buildMapPersons(entries, personsData, coordsMap, notFoundPlaces);
+
+    // Use getUngeocodedPlaces for consistency with the SSE geocode endpoint
+    const ungeocoded = this.getUngeocodedPlaces(dbId);
 
     logger.timeEnd('map', 'getAncestryMapData');
 
     return {
       persons,
-      ungeocoded: [...ungeocoded],
+      ungeocoded,
       geocodeStats: geocodeService.getGeocodeStats(),
     };
   },
@@ -261,13 +264,16 @@ export const mapService = {
     const notFoundPlaces = geocodeService.getNotFoundPlaces();
 
     // Build map persons
-    const { persons, ungeocoded } = buildMapPersons(entries, personsData, coordsMap, notFoundPlaces);
+    const { persons } = buildMapPersons(entries, personsData, coordsMap, notFoundPlaces);
+
+    // Use getUngeocodedPlaces for consistency with the SSE geocode endpoint
+    const ungeocoded = this.getUngeocodedPlaces(dbId);
 
     logger.timeEnd('map', 'getSparseTreeMapData');
 
     return {
       persons,
-      ungeocoded: [...ungeocoded],
+      ungeocoded,
       geocodeStats: geocodeService.getGeocodeStats(),
     };
   },

--- a/server/src/services/map.service.ts
+++ b/server/src/services/map.service.ts
@@ -1,0 +1,310 @@
+/**
+ * Map Data Service
+ *
+ * Assembles map visualization data by joining person/tree data
+ * with geocoded coordinates from the place_geocode cache.
+ */
+
+import type { AncestryFamilyUnit } from '@fsf/shared';
+import { sqliteService } from '../db/sqlite.service.js';
+import { geocodeService } from './geocode.service.js';
+import { ancestryTreeService } from './ancestry-tree.service.js';
+import { sparseTreeService } from './sparse-tree.service.js';
+import { databaseService } from './database.service.js';
+import { logger } from '../lib/logger.js';
+
+export interface MapCoords {
+  lat: number;
+  lng: number;
+}
+
+export interface MapPerson {
+  id: string;
+  name: string;
+  lifespan: string;
+  gender: 'male' | 'female' | 'unknown';
+  generation: number;
+  lineage: 'paternal' | 'maternal' | 'self';
+  birthPlace?: string;
+  birthCoords?: MapCoords;
+  birthYear?: number;
+  deathPlace?: string;
+  deathCoords?: MapCoords;
+  deathYear?: number;
+  photoUrl?: string;
+  isFavorite?: boolean;
+  parentId?: string;
+}
+
+export interface MapData {
+  persons: MapPerson[];
+  ungeocoded: string[];
+  geocodeStats: { resolved: number; pending: number; notFound: number; total: number };
+}
+
+/**
+ * Get person data with places from SQLite for a list of person IDs
+ */
+function getPersonsWithPlaces(personIds: string[]): Map<string, {
+  name: string;
+  gender: string;
+  birthPlace: string | null;
+  birthYear: number | null;
+  deathPlace: string | null;
+  deathYear: number | null;
+  photoUrl: string | null;
+}> {
+  const result = new Map();
+  if (personIds.length === 0) return result;
+
+  const CHUNK = 500;
+  for (let i = 0; i < personIds.length; i += CHUNK) {
+    const chunk = personIds.slice(i, i + CHUNK);
+    const placeholders = chunk.map((_, j) => `@id${j}`).join(',');
+    const params: Record<string, string> = {};
+    chunk.forEach((id, j) => { params[`id${j}`] = id; });
+
+    const rows = sqliteService.queryAll<{
+      person_id: string;
+      display_name: string;
+      gender: string | null;
+      birth_place: string | null;
+      birth_year: number | null;
+      death_place: string | null;
+      death_year: number | null;
+    }>(
+      `SELECT p.person_id, p.display_name, p.gender,
+        (SELECT place FROM vital_event WHERE person_id = p.person_id AND event_type = 'birth' LIMIT 1) as birth_place,
+        (SELECT date_year FROM vital_event WHERE person_id = p.person_id AND event_type = 'birth' LIMIT 1) as birth_year,
+        (SELECT place FROM vital_event WHERE person_id = p.person_id AND event_type = 'death' LIMIT 1) as death_place,
+        (SELECT date_year FROM vital_event WHERE person_id = p.person_id AND event_type = 'death' LIMIT 1) as death_year
+       FROM person p
+       WHERE p.person_id IN (${placeholders})`,
+      params
+    );
+
+    for (const row of rows) {
+      result.set(row.person_id, {
+        name: row.display_name,
+        gender: row.gender || 'unknown',
+        birthPlace: row.birth_place,
+        birthYear: row.birth_year,
+        deathPlace: row.death_place,
+        deathYear: row.death_year,
+        photoUrl: null, // Photos resolved separately if needed
+      });
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Flatten an ancestry tree into a list of person IDs with generation/lineage info
+ */
+function flattenAncestryTree(
+  units: AncestryFamilyUnit[] | undefined,
+  generation: number,
+  lineage: 'paternal' | 'maternal' | 'self',
+  parentId: string | undefined,
+  result: Array<{ id: string; generation: number; lineage: 'paternal' | 'maternal' | 'self'; parentId?: string }>
+): void {
+  if (!units) return;
+
+  for (const unit of units) {
+    if (unit.father) {
+      result.push({ id: unit.father.id, generation, lineage: lineage === 'self' ? 'paternal' : lineage, parentId });
+      flattenAncestryTree(unit.fatherParentUnits, generation + 1, lineage === 'self' ? 'paternal' : lineage, unit.father.id, result);
+    }
+    if (unit.mother) {
+      result.push({ id: unit.mother.id, generation, lineage: lineage === 'self' ? 'maternal' : lineage, parentId });
+      flattenAncestryTree(unit.motherParentUnits, generation + 1, lineage === 'self' ? 'maternal' : lineage, unit.mother.id, result);
+    }
+  }
+}
+
+/**
+ * Join person data with geocoded coordinates
+ */
+function buildMapPersons(
+  personEntries: Array<{ id: string; generation: number; lineage: 'paternal' | 'maternal' | 'self'; parentId?: string; isFavorite?: boolean }>,
+  personsData: Map<string, { name: string; gender: string; birthPlace: string | null; birthYear: number | null; deathPlace: string | null; deathYear: number | null; photoUrl: string | null }>,
+  coordsMap: Map<string, { lat: number; lng: number; displayName: string }>
+): { persons: MapPerson[]; ungeocoded: Set<string> } {
+  const persons: MapPerson[] = [];
+  const ungeocoded = new Set<string>();
+
+  for (const entry of personEntries) {
+    const data = personsData.get(entry.id);
+    if (!data) continue;
+
+    const birthNorm = data.birthPlace ? geocodeService.normalizePlaceText(data.birthPlace) : null;
+    const deathNorm = data.deathPlace ? geocodeService.normalizePlaceText(data.deathPlace) : null;
+
+    const birthCoords = birthNorm ? coordsMap.get(birthNorm) : undefined;
+    const deathCoords = deathNorm ? coordsMap.get(deathNorm) : undefined;
+
+    // Track ungeocoded places
+    if (data.birthPlace && !birthCoords) ungeocoded.add(data.birthPlace);
+    if (data.deathPlace && !deathCoords) ungeocoded.add(data.deathPlace);
+
+    // Only include persons with at least one geocoded place
+    const hasBirthCoords = !!birthCoords;
+    const hasDeathCoords = !!deathCoords;
+
+    const lifespan = [
+      data.birthYear ? String(data.birthYear) : '',
+      data.deathYear ? String(data.deathYear) : ''
+    ].filter(Boolean).join('-') || '';
+
+    persons.push({
+      id: entry.id,
+      name: data.name,
+      lifespan,
+      gender: data.gender as 'male' | 'female' | 'unknown',
+      generation: entry.generation,
+      lineage: entry.lineage,
+      birthPlace: data.birthPlace || undefined,
+      birthCoords: hasBirthCoords ? { lat: birthCoords!.lat, lng: birthCoords!.lng } : undefined,
+      birthYear: data.birthYear || undefined,
+      deathPlace: data.deathPlace || undefined,
+      deathCoords: hasDeathCoords ? { lat: deathCoords!.lat, lng: deathCoords!.lng } : undefined,
+      deathYear: data.deathYear || undefined,
+      isFavorite: entry.isFavorite,
+      parentId: entry.parentId,
+    });
+  }
+
+  return { persons, ungeocoded };
+}
+
+export const mapService = {
+  /**
+   * Get map data for an ancestry tree view
+   */
+  async getAncestryMapData(dbId: string, personId: string, depth = 8): Promise<MapData> {
+    logger.time('map', 'getAncestryMapData');
+
+    // Load ancestry tree
+    const tree = await ancestryTreeService.getAncestryTree(dbId, personId, depth);
+    if (!tree) {
+      return { persons: [], ungeocoded: [], geocodeStats: geocodeService.getGeocodeStats() };
+    }
+
+    // Flatten tree to list with generation/lineage
+    const entries: Array<{ id: string; generation: number; lineage: 'paternal' | 'maternal' | 'self'; parentId?: string }> = [
+      { id: tree.rootPerson.id, generation: 0, lineage: 'self' }
+    ];
+    flattenAncestryTree(tree.parentUnits, 1, 'self', tree.rootPerson.id, entries);
+
+    // Get unique person IDs
+    const personIds = [...new Set(entries.map(e => e.id))];
+
+    // Fetch person data with places
+    const personsData = getPersonsWithPlaces(personIds);
+
+    // Get all resolved coordinates
+    const coordsMap = geocodeService.getResolvedCoords();
+
+    // Build map persons
+    const { persons, ungeocoded } = buildMapPersons(entries, personsData, coordsMap);
+
+    logger.timeEnd('map', 'getAncestryMapData');
+
+    return {
+      persons,
+      ungeocoded: [...ungeocoded],
+      geocodeStats: geocodeService.getGeocodeStats(),
+    };
+  },
+
+  /**
+   * Get map data for sparse tree (favorites only)
+   */
+  async getSparseTreeMapData(dbId: string): Promise<MapData> {
+    logger.time('map', 'getSparseTreeMapData');
+
+    const sparseTree = await sparseTreeService.getSparseTree(dbId);
+
+    // Flatten sparse tree nodes
+    const entries: Array<{ id: string; generation: number; lineage: 'paternal' | 'maternal' | 'self'; parentId?: string; isFavorite?: boolean }> = [];
+
+    const flattenSparseNode = (
+      node: typeof sparseTree.root,
+      parentId?: string
+    ) => {
+      const lineage: 'paternal' | 'maternal' | 'self' =
+        node.lineageFromParent === 'paternal' ? 'paternal' :
+        node.lineageFromParent === 'maternal' ? 'maternal' :
+        node.generationFromRoot === 0 ? 'self' : 'paternal';
+
+      entries.push({
+        id: node.id,
+        generation: node.generationFromRoot,
+        lineage,
+        parentId,
+        isFavorite: node.isFavorite,
+      });
+
+      if (node.children) {
+        for (const child of node.children) {
+          flattenSparseNode(child, node.id);
+        }
+      }
+    };
+
+    flattenSparseNode(sparseTree.root);
+
+    // Get unique person IDs
+    const personIds = [...new Set(entries.map(e => e.id))];
+
+    // Fetch person data with places
+    const personsData = getPersonsWithPlaces(personIds);
+
+    // Get all resolved coordinates
+    const coordsMap = geocodeService.getResolvedCoords();
+
+    // Build map persons
+    const { persons, ungeocoded } = buildMapPersons(entries, personsData, coordsMap);
+
+    logger.timeEnd('map', 'getSparseTreeMapData');
+
+    return {
+      persons,
+      ungeocoded: [...ungeocoded],
+      geocodeStats: geocodeService.getGeocodeStats(),
+    };
+  },
+
+  /**
+   * Collect all unique places from a database that need geocoding
+   */
+  getUngeocodedPlaces(dbId: string): string[] {
+    // Get database info to find the canonical ID
+    const dbInfo = sqliteService.queryOne<{ db_id: string }>(
+      'SELECT db_id FROM database_info WHERE db_id = @dbId',
+      { dbId }
+    );
+    const resolvedDbId = dbInfo?.db_id || dbId;
+
+    // Get all unique places from persons in this database
+    const rows = sqliteService.queryAll<{ place: string }>(
+      `SELECT DISTINCT ve.place FROM vital_event ve
+       JOIN database_membership dm ON dm.person_id = ve.person_id
+       WHERE dm.db_id = @dbId AND ve.place IS NOT NULL AND ve.place != ''`,
+      { dbId: resolvedDbId }
+    );
+
+    const allPlaces = rows.map(r => r.place);
+
+    // Filter to only ungeocoded places
+    const coordsMap = geocodeService.getResolvedCoords();
+    return allPlaces.filter(place => {
+      const normalized = geocodeService.normalizePlaceText(place);
+      if (coordsMap.has(normalized)) return false;
+      // Also check if marked as not_found
+      const cached = geocodeService.lookupPlace(normalized);
+      return !cached || cached.geocode_status === 'pending' || cached.geocode_status === 'error';
+    });
+  },
+};

--- a/server/src/services/map.service.ts
+++ b/server/src/services/map.service.ts
@@ -49,10 +49,15 @@ function getPersonsWithPlaces(personIds: string[]): Map<string, {
         vb.place AS birth_place, vb.date_year AS birth_year,
         vd.place AS death_place, vd.date_year AS death_year
        FROM person p
-       LEFT JOIN vital_event vb ON vb.person_id = p.person_id AND vb.event_type = 'birth'
-       LEFT JOIN vital_event vd ON vd.person_id = p.person_id AND vd.event_type = 'death'
-       WHERE p.person_id IN (${placeholders})
-       GROUP BY p.person_id`,
+       LEFT JOIN (
+         SELECT person_id, MIN(place) AS place, MIN(date_year) AS date_year
+         FROM vital_event WHERE event_type = 'birth' GROUP BY person_id
+       ) vb ON vb.person_id = p.person_id
+       LEFT JOIN (
+         SELECT person_id, MIN(place) AS place, MIN(date_year) AS date_year
+         FROM vital_event WHERE event_type = 'death' GROUP BY person_id
+       ) vd ON vd.person_id = p.person_id
+       WHERE p.person_id IN (${placeholders})`,
       params
     );
 

--- a/server/src/services/map.service.ts
+++ b/server/src/services/map.service.ts
@@ -10,7 +10,6 @@ import { sqliteService } from '../db/sqlite.service.js';
 import { geocodeService } from './geocode.service.js';
 import { ancestryTreeService } from './ancestry-tree.service.js';
 import { sparseTreeService } from './sparse-tree.service.js';
-import { databaseService } from './database.service.js';
 import { logger } from '../lib/logger.js';
 
 export interface MapCoords {
@@ -236,7 +235,7 @@ export const mapService = {
       const lineage: 'paternal' | 'maternal' | 'self' =
         node.lineageFromParent === 'paternal' ? 'paternal' :
         node.lineageFromParent === 'maternal' ? 'maternal' :
-        node.generationFromRoot === 0 ? 'self' : 'paternal';
+        'self';
 
       entries.push({
         id: node.id,

--- a/shared/package.json
+++ b/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fsf/shared",
-  "version": "0.7.11",
+  "version": "0.7.12",
   "type": "module",
   "main": "types/index.js",
   "types": "types/index.d.ts",

--- a/shared/package.json
+++ b/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fsf/shared",
-  "version": "0.7.8",
+  "version": "0.7.9",
   "type": "module",
   "main": "types/index.js",
   "types": "types/index.d.ts",

--- a/shared/package.json
+++ b/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fsf/shared",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "type": "module",
   "main": "types/index.js",
   "types": "types/index.d.ts",

--- a/shared/package.json
+++ b/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fsf/shared",
-  "version": "0.6.33",
+  "version": "0.7.0",
   "type": "module",
   "main": "types/index.js",
   "types": "types/index.d.ts",

--- a/shared/package.json
+++ b/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fsf/shared",
-  "version": "0.7.7",
+  "version": "0.7.8",
   "type": "module",
   "main": "types/index.js",
   "types": "types/index.d.ts",

--- a/shared/package.json
+++ b/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fsf/shared",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "type": "module",
   "main": "types/index.js",
   "types": "types/index.d.ts",

--- a/shared/package.json
+++ b/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fsf/shared",
-  "version": "0.7.5",
+  "version": "0.7.6",
   "type": "module",
   "main": "types/index.js",
   "types": "types/index.d.ts",

--- a/shared/package.json
+++ b/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fsf/shared",
-  "version": "0.7.10",
+  "version": "0.7.11",
   "type": "module",
   "main": "types/index.js",
   "types": "types/index.d.ts",

--- a/shared/package.json
+++ b/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fsf/shared",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "type": "module",
   "main": "types/index.js",
   "types": "types/index.d.ts",

--- a/shared/package.json
+++ b/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fsf/shared",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "type": "module",
   "main": "types/index.js",
   "types": "types/index.d.ts",

--- a/shared/package.json
+++ b/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fsf/shared",
-  "version": "0.7.9",
+  "version": "0.7.10",
   "type": "module",
   "main": "types/index.js",
   "types": "types/index.d.ts",

--- a/shared/package.json
+++ b/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fsf/shared",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "type": "module",
   "main": "types/index.js",
   "types": "types/index.d.ts",

--- a/shared/package.json
+++ b/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fsf/shared",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "type": "module",
   "main": "types/index.js",
   "types": "types/index.d.ts",

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -886,6 +886,52 @@ export interface AncestryUpdateProgress {
   message: string;
 }
 
+// ============================================================================
+// Migration Map Types
+// ============================================================================
+
+export interface MapCoords {
+  lat: number;
+  lng: number;
+}
+
+export interface MapPerson {
+  id: string;
+  name: string;
+  lifespan: string;
+  gender: 'male' | 'female' | 'unknown';
+  generation: number;
+  lineage: 'paternal' | 'maternal' | 'self';
+  birthPlace?: string;
+  birthCoords?: MapCoords;
+  birthYear?: number;
+  deathPlace?: string;
+  deathCoords?: MapCoords;
+  deathYear?: number;
+  photoUrl?: string;
+  isFavorite?: boolean;
+  parentId?: string;
+}
+
+export interface MapData {
+  persons: MapPerson[];
+  ungeocoded: string[];
+  geocodeStats: {
+    resolved: number;
+    pending: number;
+    notFound: number;
+    total: number;
+  };
+}
+
+export interface GeocodeProgress {
+  type: 'progress' | 'complete';
+  current: number;
+  total: number;
+  place?: string;
+  status?: 'resolved' | 'not_found' | 'error' | 'cached';
+}
+
 // Status of the Ancestry update operation
 export interface AncestryUpdateStatus {
   running: boolean;

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -926,11 +926,12 @@ export interface MapData {
 }
 
 export interface GeocodeProgress {
-  type: 'progress' | 'complete';
+  type: 'progress' | 'complete' | 'error';
   current: number;
   total: number;
   place?: string;
   status?: 'resolved' | 'not_found' | 'error' | 'cached';
+  message?: string;
 }
 
 // Status of the Ancestry update operation

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -920,6 +920,7 @@ export interface MapData {
     resolved: number;
     pending: number;
     notFound: number;
+    error: number;
     total: number;
   };
 }


### PR DESCRIPTION
## Summary

- **Migration Map Visualization** — New 6th tree view mode plotting ancestors on an interactive Leaflet.js world map with lineage-colored markers, migration polylines, time range filtering, and paternal/maternal layer toggles
- **AI Discovery Dismiss** — Dismiss AI-discovered candidates individually or in batch, view/restore dismissed candidates, clear all dismissed for a database
- **AI Discovery Debug Endpoints** — Inspect recent AI runs, view prompts, outputs, and error details for failed runs
- **Geocoding Service** — Nominatim integration with permanent SQLite cache, progressive broadening for historical place names, SSE-streamed batch geocoding via EventSource

## New Features

### Migration Map (Phase 15.23)
- Leaflet.js map with OpenStreetMap (light) and CartoDB (dark) tile layers
- Lineage-colored markers: paternal (blue/teal), maternal (red/coral), self (purple)
- Migration polylines connecting parent birth → child birth locations
- Time range slider filtering ancestors by birth year
- Paternal/Maternal layer toggle checkboxes
- Auto-fit bounds on data load with click popups linking to person detail
- Sparse tree map page at `/favorites/sparse-tree/:dbId/map`
- Progressive geocode broadening: strips specific locality parts to resolve historical place names (e.g. "Cornouaile, Visseiche, Ille-et-Vilaine, Brittany, France" → "Visseiche, Ille-et-Vilaine, Brittany, France")

### AI Discovery Improvements
- Dismiss/batch-dismiss/undo-dismiss/clear-dismissed functionality
- `discovery_dismissed` SQLite table
- Debug endpoints: `GET /api/ai-discovery/debug/runs`, `GET /api/ai-discovery/debug/runs/:runId`
- Error details capture (last 10 lines stderr/stdout) on failed runs
- Fixed large prompt handling via stdin piping for CLI providers

## API Endpoints

| Method | Path | Description |
|--------|------|-------------|
| GET | `/api/map/:dbId/:personId` | Ancestry tree map data |
| GET | `/api/map/:dbId/sparse` | Sparse tree map data |
| GET | `/api/map/geocode/stream?dbId=` | SSE batch geocode stream |
| GET | `/api/map/geocode/stats` | Geocode cache statistics |
| POST | `/api/map/geocode/reset-not-found` | Reset failed entries for retry |
| POST | `/api/ai-discovery/:dbId/dismiss` | Dismiss a candidate |
| POST | `/api/ai-discovery/:dbId/dismiss-batch` | Batch dismiss candidates |
| GET | `/api/ai-discovery/:dbId/dismissed` | List dismissed candidates |
| DELETE | `/api/ai-discovery/:dbId/dismissed/:personId` | Undo dismiss |
| DELETE | `/api/ai-discovery/:dbId/dismissed` | Clear all dismissed |
| GET | `/api/ai-discovery/debug/runs` | List recent AI runs |
| GET | `/api/ai-discovery/debug/runs/:runId` | Run detail with prompt/output |

## Files Changed

**New files (10):** migrations (005, 006), geocode service, map service, map routes, MigrationMapView, SparseTreeMapPage, GeocodeProgressBar, mapUtils

**Modified files (19):** schema.sql, migrations index, server index, shared types, client api, AncestryTreeView, SparseTreePage, App.tsx, ai-discovery routes/service/modal, package files, changelog, PLAN.md, README

## Test Plan

- [ ] Navigate to any person's tree view → select "Migration Map" from view mode dropdown
- [ ] Verify map renders with tiles and auto-fits bounds
- [ ] Click "Geocode Places" → verify SSE progress streams all places
- [ ] Verify markers appear with correct lineage colors
- [ ] Verify migration polylines connect parent → child birth locations
- [ ] Test time range slider and paternal/maternal toggles
- [ ] Test dark/light theme toggle
- [ ] Navigate to Favorites → Sparse Tree → Map link
- [ ] Verify AI Discovery dismiss, batch dismiss, undo, clear all
- [ ] Verify AI Discovery debug endpoints return run data