### PR TITLE
fix: dedupe react/react-dom in Vite to stop duplicate-copy hook crash

### DIFF
--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -4,6 +4,15 @@ import tailwindcss from '@tailwindcss/vite';
 
 export default defineConfig({
   plugins: [react(), tailwindcss()],
+  // The monorepo hoists react@18 (pulled in as an optional peer of
+  // portos-ai-toolkit) to the root node_modules while the app itself uses
+  // react@19 under client/node_modules. Without deduping, hoisted packages
+  // such as react-router-dom resolve the root react@18, producing two copies
+  // of React in the browser ("Invalid hook call" / useRef on null). Force every
+  // bare react/react-dom import to resolve to the single client copy.
+  resolve: {
+    dedupe: ['react', 'react-dom'],
+  },
   server: {
     host: '0.0.0.0',
     port: 6373,


### PR DESCRIPTION
## Problem

After a fresh `pm2 start`, the web UI rendered a **blank white page** with:

```
Warning: Invalid hook call. Hooks can only be called inside of the body of a function component.
Uncaught TypeError: Cannot read properties of null (reading 'useRef')
    at BrowserRouter (react-router-dom.js)
```

This is the classic **two copies of React** symptom.

## Root cause

`portos-ai-toolkit` (added with the shared-CDP-browser change) declares `react`/`react-dom@^18.3.1` as **optional peers**. npm auto-installed them and **hoisted `react@18` + `react-dom@18` to the root `node_modules/`**, where hoisted packages (`react-router-dom`, `react-hot-toast`, `zustand`, etc.) deduped onto React 18 — while the app itself loads React 19 from `client/node_modules/`. When the hoisted `react-router-dom`'s `BrowserRouter` called `useRef`, it got the wrong/null React and crashed.

npm `overrides` can't fix this cleanly: it refuses to override the optional-peer-induced copies.

## Fix

Add `resolve.dedupe: ['react', 'react-dom']` to `client/vite.config.ts`, forcing every bare `react`/`react-dom` import (including from hoisted packages) to resolve to the single React 19 copy at the client root. This is the documented Vite remedy for "more than one copy of React".

## Verification

- Cleared the stale Vite optimize cache and restarted via PM2.
- Loaded `http://localhost:6373` in a browser: **0 console errors** (was the React hook crash); page renders.
- `react-leaflet@5` requires react@19 — dedupe to the client copy satisfies it. `scheduler` follows `react-dom` resolution and needs no entry.
- Client build passes.