### PR TITLE
fix: preserve provider operation failures (#163)

### DIFF
--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -50,6 +50,7 @@
 
 ## Fixed
 
+- **[issue-163] Provider operation failures stay actionable** — Browser connection and provider scraper failures now surface as recoverable errors instead of being reported as a logged-out session or an empty tree list.
 - Search results now keep their alphabetical ordering. The batch person-loader (`getPersonsBatch`) re-orders rows back to the requested order, fixing a regression where SQLite's `WHERE person_id IN (...)` returned rows in table order and silently discarded the search query's `ORDER BY display_name` (so the default, unsorted search view appeared randomly ordered).
 - Platform comparison now treats equivalent place spellings as matches: "Dallas, Texas, USA" vs "Dallas, Texas, United States" (and U.S.A. / United States of America / state abbreviations like TX vs Texas, UK vs United Kingdom, etc.) — no longer flagged as `different`. Place containment is now suffix-based, so "Texas" no longer falsely matches "Texarkana"
 - Platform comparison now treats equivalent date formats as matches (e.g., "1979-07-31" vs "31 JUL 1979")

--- a/client/src/pages/GenealogyProviders.tsx
+++ b/client/src/pages/GenealogyProviders.tsx
@@ -15,7 +15,8 @@ import {
   ToggleLeft,
   ToggleRight,
   ExternalLink,
-  Monitor
+  Monitor,
+  AlertCircle
 } from 'lucide-react';
 import toast from 'react-hot-toast';
 import { api, CredentialsStatus } from '../services/api';
@@ -50,6 +51,7 @@ export function GenealogyProvidersPage() {
   } = useBrowserConnection();
   const [providers, setProviders] = useState<ProviderInfo[]>([]);
   const [sessionStatus, setSessionStatus] = useState<Record<BuiltInProvider, ProviderSessionStatus>>({} as Record<BuiltInProvider, ProviderSessionStatus>);
+  const [sessionErrors, setSessionErrors] = useState<Partial<Record<BuiltInProvider, string>>>({});
   const [credentialsStatus, setCredentialsStatus] = useState<Record<BuiltInProvider, CredentialsStatus>>({} as Record<BuiltInProvider, CredentialsStatus>);
   const [loading, setLoading] = useState(true);
   const [checkingSession, setCheckingSession] = useState<BuiltInProvider | null>(null);
@@ -114,11 +116,22 @@ export function GenealogyProvidersPage() {
   const handleCheckSession = async (provider: BuiltInProvider) => {
     setCheckingSession(provider);
     const status = await api.checkProviderSession(provider).catch(err => {
+      setSessionErrors(prev => ({ ...prev, [provider]: err.message }));
+      setSessionStatus(prev => {
+        const next = { ...prev };
+        delete next[provider];
+        return next;
+      });
       toast.error(`Failed to check session: ${err.message}`);
       return null;
     });
 
     if (status) {
+      setSessionErrors(prev => {
+        const next = { ...prev };
+        delete next[provider];
+        return next;
+      });
       setSessionStatus(prev => ({ ...prev, [provider]: status }));
       if (status.loggedIn) {
         toast.success(`${provider}: Logged in${status.userName ? ` as ${status.userName}` : ''}`);
@@ -308,6 +321,7 @@ export function GenealogyProvidersPage() {
         {providers.map(({ provider, displayName, loginUrl }) => {
           const colors = providerColors[provider];
           const status = sessionStatus[provider];
+          const sessionError = sessionErrors[provider];
           const creds = credentialsStatus[provider];
           const isCheckingThis = checkingSession === provider;
           const isOpeningLoginThis = openingLogin === provider;
@@ -331,7 +345,12 @@ export function GenealogyProvidersPage() {
 
                     {/* Session Status */}
                     <div className="flex items-center gap-2">
-                      {status ? (
+                      {sessionError ? (
+                        <span className="flex items-center gap-1.5 text-app-warning">
+                          <AlertCircle size={18} />
+                          <span className="text-sm font-medium">Status unavailable</span>
+                        </span>
+                      ) : status ? (
                         status.loggedIn ? (
                           <span className="flex items-center gap-1.5 text-app-success">
                             <CheckCircle2 size={18} />
@@ -367,6 +386,29 @@ export function GenealogyProvidersPage() {
                   </button>
                 </div>
               </div>
+
+              {sessionError && (
+                <div className="mx-3 sm:mx-4 md:mx-5 mt-3 rounded-lg border border-app-warning/30 bg-app-warning-subtle p-3">
+                  <p className="text-sm text-app-warning">
+                    Could not verify this provider: {sessionError}
+                  </p>
+                  <div className="mt-2 flex flex-wrap items-center gap-3 text-xs">
+                    <Link
+                      to="/settings/browser"
+                      className="font-medium text-app-accent hover:underline"
+                    >
+                      Check browser settings
+                    </Link>
+                    <button
+                      onClick={() => handleCheckSession(provider)}
+                      disabled={isCheckingThis}
+                      className="font-medium text-app-accent hover:underline disabled:opacity-50"
+                    >
+                      Retry session check
+                    </button>
+                  </div>
+                </div>
+              )}
 
               {/* Login Options */}
               <div className="p-3 sm:p-4 md:p-5 space-y-4">

--- a/client/src/services/api.ts
+++ b/client/src/services/api.ts
@@ -24,6 +24,7 @@ import type {
   ExpandAncestryRequest,
   BuiltInProvider,
   ProviderSessionStatus,
+  ProviderTreeInfo,
   UserProviderConfig,
   ProviderComparison,
   ScrapedPersonData,
@@ -598,7 +599,7 @@ export const api = {
     }),
 
   listProviderTrees: (provider: BuiltInProvider) =>
-    fetchJson<Array<{ provider: BuiltInProvider; treeId: string; treeName: string }>>(`/scrape-providers/${provider}/trees`),
+    fetchJson<ProviderTreeInfo[]>(`/scrape-providers/${provider}/trees`),
 
   setProviderDefaultTree: (provider: BuiltInProvider, treeId?: string) =>
     fetchJson<UserProviderConfig>(`/scrape-providers/${provider}/default-tree`, {

--- a/server/src/routes/provider.routes.ts
+++ b/server/src/routes/provider.routes.ts
@@ -125,8 +125,18 @@ router.post('/:provider/check-session', async (req: Request, res: Response) => {
  * Check sessions for all enabled providers
  */
 router.post('/check-all-sessions', asyncHandler(async (_req: Request, res: Response) => {
-  const statuses = await providerService.checkAllSessions();
-  res.json({ success: true, data: statuses });
+  const summary = await providerService.checkAllSessions();
+  const failedProviders = Object.keys(summary.failures);
+  if (failedProviders.length > 0) {
+    res.status(503).json({
+      success: false,
+      error: `Failed to check ${failedProviders.length} provider session${failedProviders.length === 1 ? '' : 's'}`,
+      details: summary
+    });
+    return;
+  }
+
+  res.json({ success: true, data: summary.statuses });
 }));
 
 /**

--- a/server/src/routes/provider.routes.ts
+++ b/server/src/routes/provider.routes.ts
@@ -108,16 +108,17 @@ router.post('/:provider/confirm-browser-login', (req: Request, res: Response) =>
 router.post('/:provider/check-session', async (req: Request, res: Response) => {
   const { provider } = req.params as { provider: BuiltInProvider };
 
-  const status = await providerService.checkSession(provider)
-    .catch(err => ({
-      provider,
-      enabled: false,
-      loggedIn: false,
-      lastChecked: new Date().toISOString(),
-      error: err.message
-    }));
+  const result = await providerService.checkSession(provider);
+  if (!result.success) {
+    res.status(503).json({
+      success: false,
+      error: result.error.message,
+      details: result.error
+    });
+    return;
+  }
 
-  res.json({ success: true, data: status });
+  res.json({ success: true, data: result.data });
 });
 
 /**
@@ -173,10 +174,17 @@ router.post('/:provider/login-google', async (req: Request, res: Response) => {
 router.get('/:provider/trees', async (req: Request, res: Response) => {
   const { provider } = req.params as { provider: BuiltInProvider };
 
-  const trees = await providerService.discoverTrees(provider)
-    .catch(() => []);
+  const result = await providerService.discoverTrees(provider);
+  if (!result.success) {
+    res.status(503).json({
+      success: false,
+      error: result.error.message,
+      details: result.error
+    });
+    return;
+  }
 
-  res.json({ success: true, data: trees });
+  res.json({ success: true, data: result.data });
 });
 
 /**

--- a/server/src/services/provider.service.ts
+++ b/server/src/services/provider.service.ts
@@ -6,6 +6,8 @@ import type {
   UserProviderConfig,
   ProviderSessionStatus,
   ProviderTreeInfo,
+  ProviderOperation,
+  ProviderOperationResult,
   EnsureAuthResult
 } from '@fsf/shared';
 import { browserService, isFamilySearchAuthUrl } from './browser.service.js';
@@ -15,6 +17,33 @@ import { logger } from '../lib/logger.js';
 import { DATA_DIR } from '../utils/paths.js';
 
 const CONFIG_FILE = path.join(DATA_DIR, 'provider-config.json');
+
+const getErrorMessage = (error: unknown): string =>
+  error instanceof Error ? error.message : String(error);
+
+const runProviderOperation = async <T>(
+  provider: BuiltInProvider,
+  operation: ProviderOperation,
+  action: () => Promise<T>
+): Promise<ProviderOperationResult<T>> => action()
+  .then(data => ({ success: true as const, data }))
+  .catch(error => {
+    const message = getErrorMessage(error);
+    logger.error(
+      'provider-operation',
+      `provider=${provider} operation=${operation} error=${message}`
+    );
+
+    return {
+      success: false as const,
+      error: {
+        code: 'PROVIDER_OPERATION_FAILED' as const,
+        provider,
+        operation,
+        message
+      }
+    };
+  });
 
 /**
  * Create default configuration for all providers
@@ -186,36 +215,36 @@ export const providerService = {
   /**
    * Check browser login status for a provider
    */
-  async checkSession(provider: BuiltInProvider): Promise<ProviderSessionStatus> {
-    const config = this.getConfig(provider);
-    const scraper = getScraper(provider);
+  async checkSession(provider: BuiltInProvider): Promise<ProviderOperationResult<ProviderSessionStatus>> {
+    return runProviderOperation(provider, 'check-session', async () => {
+      const config = this.getConfig(provider);
+      const scraper = getScraper(provider);
 
-    const status: ProviderSessionStatus = {
-      provider,
-      enabled: config.enabled,
-      loggedIn: false,
-      lastChecked: new Date().toISOString()
-    };
+      const status: ProviderSessionStatus = {
+        provider,
+        enabled: config.enabled,
+        loggedIn: false,
+        lastChecked: new Date().toISOString()
+      };
 
-    // Ensure browser is connected
-    if (!browserService.isConnected()) {
-      await browserService.connect().catch(() => null);
-    }
+      if (!browserService.isConnected()) {
+        await browserService.connect();
+      }
 
-    if (!browserService.isConnected()) {
+      if (!browserService.isConnected()) {
+        throw new Error('Browser connection was not established');
+      }
+
+      const page = await browserService.getWorkerPage();
+      status.loggedIn = await scraper.checkLoginStatus(page);
+
+      if (status.loggedIn) {
+        const userInfo = await scraper.getLoggedInUser(page).catch(() => null);
+        status.userName = userInfo?.name;
+      }
+
       return status;
-    }
-
-    const page = await browserService.getWorkerPage();
-
-    status.loggedIn = await scraper.checkLoginStatus(page).catch(() => false);
-
-    if (status.loggedIn) {
-      const userInfo = await scraper.getLoggedInUser(page).catch(() => null);
-      status.userName = userInfo?.name;
-    }
-
-    return status;
+    });
   },
 
   /**
@@ -333,7 +362,11 @@ export const providerService = {
 
     for (const provider of listProviders()) {
       if (registry.providers[provider].enabled) {
-        results[provider] = await this.checkSession(provider);
+        const result = await this.checkSession(provider);
+        if (!result.success) {
+          throw new Error(result.error.message);
+        }
+        results[provider] = result.data;
       } else {
         results[provider] = {
           provider,
@@ -350,17 +383,21 @@ export const providerService = {
   /**
    * Discover available trees for a provider
    */
-  async discoverTrees(provider: BuiltInProvider): Promise<ProviderTreeInfo[]> {
-    const scraper = getScraper(provider);
+  async discoverTrees(provider: BuiltInProvider): Promise<ProviderOperationResult<ProviderTreeInfo[]>> {
+    return runProviderOperation(provider, 'discover-trees', async () => {
+      const scraper = getScraper(provider);
 
-    if (!browserService.isConnected()) {
-      await browserService.connect();
-    }
+      if (!browserService.isConnected()) {
+        await browserService.connect();
+      }
 
-    const page = await browserService.getWorkerPage();
-    const trees = await scraper.listTrees(page).catch(() => []);
+      if (!browserService.isConnected()) {
+        throw new Error('Browser connection was not established');
+      }
 
-    return trees;
+      const page = await browserService.getWorkerPage();
+      return scraper.listTrees(page);
+    });
   },
 
   /**

--- a/server/src/services/provider.service.ts
+++ b/server/src/services/provider.service.ts
@@ -8,6 +8,7 @@ import type {
   ProviderTreeInfo,
   ProviderOperation,
   ProviderOperationResult,
+  ProviderSessionCheckSummary,
   EnsureAuthResult
 } from '@fsf/shared';
 import { browserService, isFamilySearchAuthUrl } from './browser.service.js';
@@ -356,19 +357,21 @@ export const providerService = {
   /**
    * Check session status for all enabled providers
    */
-  async checkAllSessions(): Promise<Record<BuiltInProvider, ProviderSessionStatus>> {
-    const registry = loadRegistry();
-    const results: Record<BuiltInProvider, ProviderSessionStatus> = {} as Record<BuiltInProvider, ProviderSessionStatus>;
+  async checkAllSessions(): Promise<ProviderSessionCheckSummary> {
+    const registry = this.getAllConfigs();
+    const statuses: ProviderSessionCheckSummary['statuses'] = {};
+    const failures: ProviderSessionCheckSummary['failures'] = {};
 
     for (const provider of listProviders()) {
       if (registry.providers[provider].enabled) {
         const result = await this.checkSession(provider);
-        if (!result.success) {
-          throw new Error(result.error.message);
+        if (result.success) {
+          statuses[provider] = result.data;
+        } else {
+          failures[provider] = result.error;
         }
-        results[provider] = result.data;
       } else {
-        results[provider] = {
+        statuses[provider] = {
           provider,
           enabled: false,
           loggedIn: false,
@@ -377,7 +380,7 @@ export const providerService = {
       }
     }
 
-    return results;
+    return { statuses, failures };
   },
 
   /**

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -189,6 +189,19 @@ export interface ProviderTreeInfo {
   rootPersonId?: string;
 }
 
+export type ProviderOperation = 'check-session' | 'discover-trees';
+
+export interface ProviderOperationFailure {
+  code: 'PROVIDER_OPERATION_FAILED';
+  provider: BuiltInProvider;
+  operation: ProviderOperation;
+  message: string;
+}
+
+export type ProviderOperationResult<T> =
+  | { success: true; data: T }
+  | { success: false; error: ProviderOperationFailure };
+
 // Auto-login method type
 export type AutoLoginMethod = 'credentials' | 'google';
 

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -202,6 +202,11 @@ export type ProviderOperationResult<T> =
   | { success: true; data: T }
   | { success: false; error: ProviderOperationFailure };
 
+export interface ProviderSessionCheckSummary {
+  statuses: Partial<Record<BuiltInProvider, ProviderSessionStatus>>;
+  failures: Partial<Record<BuiltInProvider, ProviderOperationFailure>>;
+}
+
 // Auto-login method type
 export type AutoLoginMethod = 'credentials' | 'google';
 

--- a/tests/integration/api/providers.spec.ts
+++ b/tests/integration/api/providers.spec.ts
@@ -5,6 +5,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const mocks = vi.hoisted(() => ({
   providerService: {
     checkSession: vi.fn(),
+    checkAllSessions: vi.fn(),
     discoverTrees: vi.fn(),
   },
 }));
@@ -85,6 +86,47 @@ describe('Provider routes', () => {
         provider: 'familysearch',
         operation: 'check-session',
         message: 'CDP refused connection',
+      },
+    });
+  });
+
+  it('returns successful statuses and structured failures from aggregate checks', async () => {
+    mocks.providerService.checkAllSessions.mockResolvedValue({
+      statuses: {
+        ancestry: {
+          provider: 'ancestry',
+          enabled: true,
+          loggedIn: true,
+        },
+      },
+      failures: {
+        familysearch: failure('check-session', 'CDP refused connection').error,
+      },
+    });
+
+    const response = await request(app)
+      .post('/api/scrape-providers/check-all-sessions')
+      .expect(503);
+
+    expect(response.body).toEqual({
+      success: false,
+      error: 'Failed to check 1 provider session',
+      details: {
+        statuses: {
+          ancestry: {
+            provider: 'ancestry',
+            enabled: true,
+            loggedIn: true,
+          },
+        },
+        failures: {
+          familysearch: {
+            code: 'PROVIDER_OPERATION_FAILED',
+            provider: 'familysearch',
+            operation: 'check-session',
+            message: 'CDP refused connection',
+          },
+        },
       },
     });
   });

--- a/tests/integration/api/providers.spec.ts
+++ b/tests/integration/api/providers.spec.ts
@@ -1,0 +1,122 @@
+import express from 'express';
+import request from 'supertest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  providerService: {
+    checkSession: vi.fn(),
+    discoverTrees: vi.fn(),
+  },
+}));
+
+vi.mock('../../../server/src/services/provider.service.js', () => ({
+  providerService: mocks.providerService,
+}));
+
+vi.mock('../../../server/src/services/browser.service.js', () => ({
+  browserService: {},
+}));
+
+vi.mock('../../../server/src/services/credentials.service.js', () => ({
+  credentialsService: {},
+}));
+
+const { providerRouter } = await import('../../../server/src/routes/provider.routes.js');
+
+const app = express();
+app.use(express.json());
+app.use('/api/scrape-providers', providerRouter);
+
+const failure = (operation: 'check-session' | 'discover-trees', message: string) => ({
+  success: false as const,
+  error: {
+    code: 'PROVIDER_OPERATION_FAILED' as const,
+    provider: 'familysearch' as const,
+    operation,
+    message,
+  },
+});
+
+describe('Provider routes', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns a successful logged-out session only when it was verified', async () => {
+    mocks.providerService.checkSession.mockResolvedValue({
+      success: true,
+      data: {
+        provider: 'familysearch',
+        enabled: true,
+        loggedIn: false,
+        lastChecked: '2026-08-30T00:00:00.000Z',
+      },
+    });
+
+    const response = await request(app)
+      .post('/api/scrape-providers/familysearch/check-session')
+      .expect(200);
+
+    expect(response.body).toEqual({
+      success: true,
+      data: {
+        provider: 'familysearch',
+        enabled: true,
+        loggedIn: false,
+        lastChecked: '2026-08-30T00:00:00.000Z',
+      },
+    });
+  });
+
+  it('returns a non-2xx error envelope for an operational session failure', async () => {
+    mocks.providerService.checkSession.mockResolvedValue(
+      failure('check-session', 'CDP refused connection')
+    );
+
+    const response = await request(app)
+      .post('/api/scrape-providers/familysearch/check-session')
+      .expect(503);
+
+    expect(response.body).toEqual({
+      success: false,
+      error: 'CDP refused connection',
+      details: {
+        code: 'PROVIDER_OPERATION_FAILED',
+        provider: 'familysearch',
+        operation: 'check-session',
+        message: 'CDP refused connection',
+      },
+    });
+  });
+
+  it('returns an empty tree list only when discovery succeeded', async () => {
+    mocks.providerService.discoverTrees.mockResolvedValue({ success: true, data: [] });
+
+    const response = await request(app)
+      .get('/api/scrape-providers/familysearch/trees')
+      .expect(200);
+
+    expect(response.body).toEqual({ success: true, data: [] });
+  });
+
+  it('returns a non-2xx error envelope when tree discovery fails', async () => {
+    mocks.providerService.discoverTrees.mockResolvedValue(
+      failure('discover-trees', 'Tree scraper failed')
+    );
+
+    const response = await request(app)
+      .get('/api/scrape-providers/familysearch/trees')
+      .expect(503);
+
+    expect(response.body).toEqual({
+      success: false,
+      error: 'Tree scraper failed',
+      details: {
+        code: 'PROVIDER_OPERATION_FAILED',
+        provider: 'familysearch',
+        operation: 'discover-trees',
+        message: 'Tree scraper failed',
+      },
+    });
+  });
+});

--- a/tests/unit/services/providerService.spec.ts
+++ b/tests/unit/services/providerService.spec.ts
@@ -1,0 +1,140 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  browserService: {
+    isConnected: vi.fn(),
+    connect: vi.fn(),
+    getWorkerPage: vi.fn(),
+  },
+  scraper: {
+    checkLoginStatus: vi.fn(),
+    getLoggedInUser: vi.fn(),
+    listTrees: vi.fn(),
+  },
+  logger: {
+    error: vi.fn(),
+  },
+}));
+
+vi.mock('../../../server/src/services/browser.service.js', () => ({
+  browserService: mocks.browserService,
+  isFamilySearchAuthUrl: vi.fn(),
+}));
+
+vi.mock('../../../server/src/services/credentials.service.js', () => ({
+  credentialsService: {},
+}));
+
+vi.mock('../../../server/src/services/scrapers/index.js', () => ({
+  getScraper: vi.fn(() => mocks.scraper),
+  getProviderInfo: vi.fn(),
+  listProviders: vi.fn(() => ['familysearch']),
+  PROVIDER_DEFAULTS: {},
+}));
+
+vi.mock('../../../server/src/lib/logger.js', () => ({
+  logger: mocks.logger,
+}));
+
+const { providerService } = await import('../../../server/src/services/provider.service.js');
+
+describe('providerService operational failures', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.clearAllMocks();
+
+    vi.spyOn(providerService, 'getConfig').mockReturnValue({
+      provider: 'familysearch',
+      enabled: true,
+      rateLimit: { minDelayMs: 1000, maxDelayMs: 2000 },
+      browserScrapeEnabled: true,
+      browserLoggedIn: false,
+    });
+    mocks.browserService.isConnected.mockReturnValue(true);
+    mocks.browserService.getWorkerPage.mockResolvedValue({});
+    mocks.scraper.checkLoginStatus.mockResolvedValue(false);
+    mocks.scraper.getLoggedInUser.mockResolvedValue(null);
+    mocks.scraper.listTrees.mockResolvedValue([]);
+  });
+
+  it('returns a failure result and logs context when the CDP connection rejects', async () => {
+    mocks.browserService.isConnected.mockReturnValue(false);
+    mocks.browserService.connect.mockRejectedValue(new Error('CDP refused connection'));
+
+    const result = await providerService.checkSession('familysearch');
+
+    expect(result).toEqual({
+      success: false,
+      error: {
+        code: 'PROVIDER_OPERATION_FAILED',
+        provider: 'familysearch',
+        operation: 'check-session',
+        message: 'CDP refused connection',
+      },
+    });
+    expect(mocks.logger.error).toHaveBeenCalledWith(
+      'provider-operation',
+      'provider=familysearch operation=check-session error=CDP refused connection'
+    );
+  });
+
+  it('keeps a verified logged-out session as a successful negative result', async () => {
+    const result = await providerService.checkSession('familysearch');
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data).toMatchObject({
+        provider: 'familysearch',
+        enabled: true,
+        loggedIn: false,
+      });
+    }
+    expect(mocks.logger.error).not.toHaveBeenCalled();
+  });
+
+  it('returns a failure result when the provider login-status check rejects', async () => {
+    mocks.scraper.checkLoginStatus.mockRejectedValue(new Error('Login markup changed'));
+
+    const result = await providerService.checkSession('familysearch');
+
+    expect(result).toMatchObject({
+      success: false,
+      error: {
+        provider: 'familysearch',
+        operation: 'check-session',
+        message: 'Login markup changed',
+      },
+    });
+    expect(mocks.logger.error).toHaveBeenCalledWith(
+      'provider-operation',
+      'provider=familysearch operation=check-session error=Login markup changed'
+    );
+  });
+
+  it('keeps a verified empty tree list as a successful negative result', async () => {
+    const result = await providerService.discoverTrees('familysearch');
+
+    expect(result).toEqual({ success: true, data: [] });
+    expect(mocks.logger.error).not.toHaveBeenCalled();
+  });
+
+  it('returns a failure result and logs context when tree discovery rejects', async () => {
+    mocks.scraper.listTrees.mockRejectedValue(new Error('Tree scraper failed'));
+
+    const result = await providerService.discoverTrees('familysearch');
+
+    expect(result).toEqual({
+      success: false,
+      error: {
+        code: 'PROVIDER_OPERATION_FAILED',
+        provider: 'familysearch',
+        operation: 'discover-trees',
+        message: 'Tree scraper failed',
+      },
+    });
+    expect(mocks.logger.error).toHaveBeenCalledWith(
+      'provider-operation',
+      'provider=familysearch operation=discover-trees error=Tree scraper failed'
+    );
+  });
+});

--- a/tests/unit/services/providerService.spec.ts
+++ b/tests/unit/services/providerService.spec.ts
@@ -50,6 +50,18 @@ describe('providerService operational failures', () => {
       browserScrapeEnabled: true,
       browserLoggedIn: false,
     });
+    vi.spyOn(providerService, 'getAllConfigs').mockReturnValue({
+      providers: {
+        familysearch: {
+          provider: 'familysearch',
+          enabled: true,
+          rateLimit: { minDelayMs: 1000, maxDelayMs: 2000 },
+          browserScrapeEnabled: true,
+          browserLoggedIn: false,
+        },
+      },
+      lastUpdated: '2026-08-30T00:00:00.000Z',
+    } as ReturnType<typeof providerService.getAllConfigs>);
     mocks.browserService.isConnected.mockReturnValue(true);
     mocks.browserService.getWorkerPage.mockResolvedValue({});
     mocks.scraper.checkLoginStatus.mockResolvedValue(false);
@@ -109,6 +121,22 @@ describe('providerService operational failures', () => {
       'provider-operation',
       'provider=familysearch operation=check-session error=Login markup changed'
     );
+  });
+
+  it('preserves successful statuses and structured failures in aggregate checks', async () => {
+    mocks.scraper.checkLoginStatus.mockRejectedValue(new Error('Login markup changed'));
+
+    const summary = await providerService.checkAllSessions();
+
+    expect(summary.statuses).toEqual({});
+    expect(summary.failures).toEqual({
+      familysearch: {
+        code: 'PROVIDER_OPERATION_FAILED',
+        provider: 'familysearch',
+        operation: 'check-session',
+        message: 'Login markup changed',
+      },
+    });
   });
 
   it('keeps a verified empty tree list as a successful negative result', async () => {


### PR DESCRIPTION
## Summary

- distinguish verified logged-out and empty-tree states from browser or provider scraper failures
- return structured HTTP 503 errors with provider and operation context, including partial aggregate-session results
- keep provider-session failures visible in the UI with browser-settings and retry remediation

## Tests

- `npm test -- --run tests/unit/services/providerService.spec.ts tests/integration/api/providers.spec.ts` (11 passed)
- `npm test -- --run` (186 passed, 2 skipped)
- `npm run build`
- `npm run check:file-sizes`

## Review

- Claude local review at medium effort completed for the configured one-round cap
- addressed both findings: aggregate result preservation and aggregate failure coverage

Closes #163
